### PR TITLE
[FLINK-30427][Connector/Pulsar] Correct scope for bouncycastle dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -450,23 +450,22 @@ under the License.
                 <groupId>com.google.code.gson</groupId>
                 <artifactId>gson</artifactId>
                 <version>2.8.9</version>
-                <scope>test</scope>
             </dependency>
 
-            <!-- For test dependency convergence -->
+            <!-- For dependency convergence -->
             <dependency>
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bcprov-ext-jdk15on</artifactId>
                 <version>${bouncycastle.version}</version>
-                <scope>test</scope>
+                <scope>compile</scope>
             </dependency>
 
-            <!-- For test dependency convergence -->
+            <!-- For dependency convergence -->
             <dependency>
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bcpkix-jdk15on</artifactId>
                 <version>${bouncycastle.version}</version>
-                <scope>test</scope>
+                <scope>compile</scope>
             </dependency>
 
             <!-- For dependency convergence -->


### PR DESCRIPTION
Dependency tree from Flink's repo (before externalization):

```
[INFO] +- org.apache.pulsar:pulsar-client-all:jar:2.10.2:compile
[INFO] |  +- org.apache.pulsar:pulsar-client-api:jar:2.10.2:compile
[INFO] |  +- org.apache.pulsar:bouncy-castle-bc:jar:pkg:2.10.2:compile
[INFO] |  +- org.bouncycastle:bcpkix-jdk15on:jar:1.69:compile
[INFO] |  +- org.bouncycastle:bcprov-jdk15on:jar:1.69:compile
[INFO] |  +- org.bouncycastle:bcutil-jdk15on:jar:1.69:compile
[INFO] |  +- org.bouncycastle:bcprov-ext-jdk15on:jar:1.69:compile
```

Dependency tree from this repo (before this PR):
```
[INFO] |  \- org.apache.pulsar:pulsar-client-all:jar:2.10.2:compile
[INFO] |     +- org.apache.pulsar:pulsar-client-api:jar:2.10.2:compile
[INFO] |     +- org.apache.pulsar:bouncy-castle-bc:jar:pkg:2.10.2:compile
[INFO] |     +- org.bouncycastle:bcpkix-jdk15on:jar:1.69:test
[INFO] |     +- org.bouncycastle:bcprov-jdk15on:jar:1.69:compile
[INFO] |     +- org.bouncycastle:bcutil-jdk15on:jar:1.69:compile
[INFO] |     +- org.bouncycastle:bcprov-ext-jdk15on:jar:1.69:test
```

Dependency tree from this repo (locally, with the changes from this PR):
```
[INFO] +- org.apache.pulsar:pulsar-client-all:jar:2.10.2:compile
[INFO] |  +- org.apache.pulsar:pulsar-client-api:jar:2.10.2:compile
[INFO] |  +- org.apache.pulsar:bouncy-castle-bc:jar:pkg:2.10.2:compile
[INFO] |  +- org.bouncycastle:bcpkix-jdk15on:jar:1.69:compile
[INFO] |  +- org.bouncycastle:bcprov-jdk15on:jar:1.69:compile
[INFO] |  +- org.bouncycastle:bcutil-jdk15on:jar:1.69:compile
[INFO] |  +- org.bouncycastle:bcprov-ext-jdk15on:jar:1.69:compile
```