### PR TITLE
[FLINK-30654][Connector/Pulsar] Add an option to force consumption from StartCursor every time the application starts.

### DIFF
--- a/docs/content.zh/docs/connectors/datastream/pulsar.md
+++ b/docs/content.zh/docs/connectors/datastream/pulsar.md
@@ -339,6 +339,8 @@ Pulsar Source 使用 `setStartCursor(StartCursor)` 方法给定开始消费的�
   {{< /tab >}}
   {{< /tabs >}}
 
+`StartCursor` 仅用于创建订阅的初始位置，消费初始位置的优先级顺序为：检查点 > 已有订阅里的起始位置 > `StartCursor`。但有时候，用户想一直使用 `StartCursor` 给定的位置作为起始消费的位置。此时，你可以通过启用 `pulsar.source.resetSubscriptionCursor` 配置项，并不基于 checkpoint 对应的文件启动程序来实现对应的诉求。需要注意的是，checkpoint 中给定的消费位置永远是最高优先级的。
+
 {{< hint info >}}
 每条消息都有一个固定的序列号，这个序列号在 Pulsar 上有序排列，其包含了 ledger、entry、partition 等原始信息，用于在 Pulsar 底层存储上查找到具体的消息。
 

--- a/docs/content/docs/connectors/datastream/pulsar.md
+++ b/docs/content/docs/connectors/datastream/pulsar.md
@@ -398,6 +398,12 @@ You can use `StartCursor.fromPublishTime(long)` instead.
   {{< /tab >}}
   {{< /tabs >}}
 
+The `StartCursor` is used when the corresponding subscription is not created in Pulsar by default.
+The priority of the consumption start position is, checkpoint > existed subscription position > `StartCursor`.
+Sometimes, the end user may want to force the start position by using `StartCursor`. You should enable the `pulsar.source.resetSubscriptionCursor`
+option and start the pipeline without the saved checkpoint files.
+It is important to note that the given consumption position in the checkpoint is always the highest priority.
+
 {{< hint info >}}
 Each Pulsar message belongs to an ordered sequence on its topic.
 The sequence ID (`MessageId`) of the message is ordered in that sequence.

--- a/docs/layouts/shortcodes/generated/pulsar_source_configuration.html
+++ b/docs/layouts/shortcodes/generated/pulsar_source_configuration.html
@@ -63,6 +63,12 @@
             <td>The interval (in ms) for the Pulsar source to discover the new partitions. A non-positive value disables the partition discovery.</td>
         </tr>
         <tr>
+            <td><h5>pulsar.source.resetSubscriptionCursor</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>The <code class="highlighter-rouge">StartCursor</code> in connector is used to create the initial subscription. Enable this option will reset the start cursor in subscription by using <code class="highlighter-rouge">StartCursor</code> everytime you start the application without the checkpoint.</td>
+        </tr>
+        <tr>
             <td><h5>pulsar.source.verifyInitialOffsets</h5></td>
             <td style="word-wrap: break-word;">WARN_ON_MISMATCH</td>
             <td><p>Enum</p></td>

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/PulsarSourceOptions.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/PulsarSourceOptions.java
@@ -216,6 +216,22 @@ public final class PulsarSourceOptions {
                                             code(PULSAR_STATS_INTERVAL_SECONDS.key()))
                                     .build());
 
+    public static final ConfigOption<Boolean> PULSAR_RESET_SUBSCRIPTION_CURSOR =
+            ConfigOptions.key(SOURCE_CONFIG_PREFIX + "resetSubscriptionCursor")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "The %s in connector is used to create the initial subscription.",
+                                            code("StartCursor"))
+                                    .text(
+                                            " Enable this option will reset the start cursor in subscription")
+                                    .text(
+                                            " by using %s everytime you start the application without the checkpoint.",
+                                            code("StartCursor"))
+                                    .build());
+
     ///////////////////////////////////////////////////////////////////////////////
     //
     // The configuration for ConsumerConfigurationData part.

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/config/SourceConfiguration.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/config/SourceConfiguration.java
@@ -44,6 +44,7 @@ import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSA
 import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_MAX_FETCH_TIME;
 import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_PARTITION_DISCOVERY_INTERVAL_MS;
 import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_READ_SCHEMA_EVOLUTION;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_RESET_SUBSCRIPTION_CURSOR;
 import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_SUBSCRIPTION_MODE;
 import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_SUBSCRIPTION_NAME;
 import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_VERIFY_INITIAL_OFFSETS;
@@ -66,6 +67,7 @@ public class SourceConfiguration extends PulsarConfiguration {
     private final boolean allowKeySharedOutOfOrderDelivery;
     private final boolean enableSchemaEvolution;
     private final boolean enableMetrics;
+    private final boolean resetSubscriptionCursor;
 
     public SourceConfiguration(Configuration configuration) {
         super(configuration);
@@ -84,6 +86,7 @@ public class SourceConfiguration extends PulsarConfiguration {
         this.enableSchemaEvolution = get(PULSAR_READ_SCHEMA_EVOLUTION);
         this.enableMetrics =
                 get(PULSAR_ENABLE_SOURCE_METRICS) && get(PULSAR_STATS_INTERVAL_SECONDS) > 0;
+        this.resetSubscriptionCursor = get(PULSAR_RESET_SUBSCRIPTION_CURSOR);
     }
 
     /** The capacity of the element queue in the source reader. */
@@ -196,6 +199,11 @@ public class SourceConfiguration extends PulsarConfiguration {
         return enableMetrics;
     }
 
+    /** Whether to reset the start cursor in subscription. */
+    public boolean isResetSubscriptionCursor() {
+        return resetSubscriptionCursor;
+    }
+
     /** Convert the subscription into a readable str. */
     public String getSubscriptionDesc() {
         return getSubscriptionName() + "(Exclusive," + getSubscriptionMode() + ")";
@@ -225,7 +233,8 @@ public class SourceConfiguration extends PulsarConfiguration {
                 && subscriptionMode == that.subscriptionMode
                 && allowKeySharedOutOfOrderDelivery == that.allowKeySharedOutOfOrderDelivery
                 && enableSchemaEvolution == that.enableSchemaEvolution
-                && enableMetrics == that.enableMetrics;
+                && enableMetrics == that.enableMetrics
+                && resetSubscriptionCursor == that.resetSubscriptionCursor;
     }
 
     @Override
@@ -244,6 +253,7 @@ public class SourceConfiguration extends PulsarConfiguration {
                 subscriptionMode,
                 allowKeySharedOutOfOrderDelivery,
                 enableSchemaEvolution,
-                enableMetrics);
+                enableMetrics,
+                resetSubscriptionCursor);
     }
 }

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/PulsarSourceEnumerator.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/PulsarSourceEnumerator.java
@@ -215,13 +215,17 @@ public class PulsarSourceEnumerator
     /** Create subscription on topic partition if it doesn't exist. */
     private void createSubscription(List<TopicPartition> newPartitions) {
         for (TopicPartition partition : newPartitions) {
-            String topicName = partition.getFullTopicName();
+            String topic = partition.getFullTopicName();
             String subscriptionName = sourceConfiguration.getSubscriptionName();
             CursorPosition position =
                     startCursor.position(partition.getTopic(), partition.getPartitionId());
 
-            sneakyAdmin(
-                    () -> position.createInitialPosition(pulsarAdmin, topicName, subscriptionName));
+            if (sourceConfiguration.isResetSubscriptionCursor()) {
+                sneakyAdmin(() -> position.seekPosition(pulsarAdmin, topic, subscriptionName));
+            } else {
+                sneakyAdmin(
+                        () -> position.createInitialPosition(pulsarAdmin, topic, subscriptionName));
+            }
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change

This PR supports to set the `StartCursor` as the default start position for consuming.

## Brief change log

- Add a new `PULSAR_RESET_SUBSCRIPTION_CURSOR` option in `PulsarSourceOptions`

## Verifying this change

This change is a minor change and don't have any tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs, JavaDocs)
