### PR TITLE
[FLINK-24302][Connector/Pulsar] Drop the use of direct buffer memory for supporting Java 11.

### DIFF
--- a/docs/content.zh/docs/connectors/datastream/pulsar.md
+++ b/docs/content.zh/docs/connectors/datastream/pulsar.md
@@ -28,7 +28,7 @@ Flink 当前提供 [Apache Pulsar](https://pulsar.apache.org) Source 和 Sink �
 
 ## 添加依赖
 
-当前支持 Pulsar 2.10.0 及其之后的版本，建议在总是将 Pulsar 升级至最新版。如果想要了解更多关于 Pulsar API 兼容性设计，可以阅读文档 [PIP-72](https://github.com/apache/pulsar/wiki/PIP-72%3A-Introduce-Pulsar-Interface-Taxonomy%3A-Audience-and-Stability-Classification)。
+当前支持 Pulsar 2.10.0 及其之后的版本，建议总是将 Pulsar 升级至最新版。如果想要了解更多关于 Pulsar API 兼容性设计，可以阅读文档 [PIP-72](https://github.com/apache/pulsar/wiki/PIP-72%3A-Introduce-Pulsar-Interface-Taxonomy%3A-Audience-and-Stability-Classification)。
 
 {{< connector_artifact flink-connector-pulsar 4.0.0-SNAPSHOT >}}
 
@@ -1088,21 +1088,9 @@ PulsarSink<String> sink = PulsarSink.builder()
 
 用户遇到的问题可能与 Flink 无关，请先升级 Pulsar 的版本、Pulsar 客户端的版本，或者修改 Pulsar 的配置、Pulsar 连接器的配置来尝试解决问题。
 
-## 已知问题
+## 使用 Java 11 或者之后的版本运行连接器
 
-本节介绍有关 Pulsar 连接器的一些已知问题。
-
-### 在 Java 11 上使用不稳定
-
-Pulsar connector 在 Java 11 中有一些尚未修复的问题。我们当前推荐在 Java 8 环境中运行Pulsar connector.
-
-### 不自动重连，而是抛出TransactionCoordinatorNotFound异常
-
-Pulsar 事务机制仍在积极发展中，当前版本并不稳定。 Pulsar 2.9.2
-引入了这个问题 [a break change](https://github.com/apache/pulsar/pull/13135)。
-如果您使用 Pulsar 2.9.2或更高版本与较旧的 Pulsar 客户端一起使用，您可能会收到一个“TransactionCoordinatorNotFound”异常。
-
-您可以使用最新的`pulsar-client-all`分支来解决这个问题。
+Pulsar 自身已经基于 Java 17 开发，但是 Pulsar 的 client 还能在 Java 8 上运行。之前使用 Java 11 之后的版本运行连接器会遇到 direct buffer 内存泄漏的问题。为了解决此问题，在 source 和 sink 端都增加了内存限制。同时请确保 `-Dpulsar.allocator.pooled=false` 配置加在了 JobManager 和 TaskManager 的 `env.java.opts` 配置中。
 
 {{< top >}}
 

--- a/docs/content/docs/connectors/datastream/pulsar.md
+++ b/docs/content/docs/connectors/datastream/pulsar.md
@@ -1276,22 +1276,12 @@ If you have a problem with Pulsar when using Flink, keep in mind that Flink only
 and your problem might be independent of Flink and sometimes can be solved by upgrading Pulsar brokers,
 reconfiguring Pulsar brokers or reconfiguring Pulsar connector in Flink.
 
-## Known Issues
+## Using the Connector on Java 11 or above
 
-This section describes some known issues about the Pulsar connectors.
-
-### Unstable on Java 11
-
-Pulsar connector has some known issues on Java 11. It is recommended to run Pulsar connector
-on Java 8.
-
-### No TransactionCoordinatorNotFound, but automatic reconnect
-
-Pulsar transactions are still in active development and are not stable. Pulsar 2.9.2
-introduces [a break change](https://github.com/apache/pulsar/pull/13135) in transactions.
-If you use Pulsar 2.9.2 or higher with an older Pulsar client, you might get a `TransactionCoordinatorNotFound` exception.
-
-You can use the latest `pulsar-client-all` release to resolve this issue.
+Pulsar has been target to Java 17 while the client is still Java 8 compatible. We have an direct buffer memory leak
+issue in using Pulsar connector with Java 11. To solve this problem, we add memory limit in both source and sink.
+And make sure you have added the `-Dpulsar.allocator.pooled=false` arg to your Flink `env.java.opts` in both JobManager
+and TaskManager.
 
 {{< top >}}
 

--- a/flink-connector-pulsar-e2e-tests/src/test/java/org/apache/flink/tests/util/pulsar/common/FlinkContainerWithPulsarEnvironment.java
+++ b/flink-connector-pulsar-e2e-tests/src/test/java/org/apache/flink/tests/util/pulsar/common/FlinkContainerWithPulsarEnvironment.java
@@ -19,6 +19,7 @@
 package org.apache.flink.tests.util.pulsar.common;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.TaskManagerOptions;
@@ -46,6 +47,11 @@ public class FlinkContainerWithPulsarEnvironment extends FlinkContainerTestEnvir
         configuration.set(TaskManagerOptions.JVM_METASPACE, MemorySize.ofMebiBytes(512));
         configuration.set(JobManagerOptions.TOTAL_PROCESS_MEMORY, MemorySize.ofMebiBytes(2048));
         configuration.set(JobManagerOptions.JVM_METASPACE, MemorySize.ofMebiBytes(512));
+
+        // Disable Pulsar direct buffer memory allocation.
+        configuration.set(
+                CoreOptions.FLINK_JVM_OPTIONS,
+                "-Dpulsar.allocator.pooled=false -Dpulsar.allocator.leak_detection=Simple");
 
         return configuration;
     }

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/config/PulsarSourceConfigUtils.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/config/PulsarSourceConfigUtils.java
@@ -39,6 +39,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_ADMIN_URL;
 import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_AUTH_PARAMS;
 import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_AUTH_PARAM_MAP;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_MEMORY_LIMIT_BYTES;
 import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_SERVICE_URL;
 import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_ACKNOWLEDGEMENTS_GROUP_TIME_MICROS;
 import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_ACK_RECEIPT_ENABLED;
@@ -131,9 +132,15 @@ public final class PulsarSourceConfigUtils {
                 PULSAR_EXPIRE_TIME_OF_INCOMPLETE_CHUNKED_MESSAGE_MILLIS,
                 v -> builder.expireTimeOfIncompleteChunkedMessage(v, MILLISECONDS));
         configuration.useOption(PULSAR_POOL_MESSAGES, builder::poolMessages);
-        configuration.useOption(
-                PULSAR_AUTO_SCALED_RECEIVER_QUEUE_SIZE_ENABLED,
-                builder::autoScaledReceiverQueueSizeEnabled);
+
+        if (configuration.contains(PULSAR_MEMORY_LIMIT_BYTES)) {
+            // Force to scale the receiver queue size if the memory limit has been configured.
+            builder.autoScaledReceiverQueueSizeEnabled(true);
+        } else {
+            configuration.useOption(
+                    PULSAR_AUTO_SCALED_RECEIVER_QUEUE_SIZE_ENABLED,
+                    builder::autoScaledReceiverQueueSizeEnabled);
+        }
 
         Map<String, String> properties = configuration.getProperties(PULSAR_CONSUMER_PROPERTIES);
         if (!properties.isEmpty()) {

--- a/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/sink/PulsarSinkITCase.java
+++ b/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/sink/PulsarSinkITCase.java
@@ -43,7 +43,6 @@ import org.apache.flink.test.junit5.MiniClusterExtension;
 import org.apache.flink.testutils.junit.SharedObjectsExtension;
 
 import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -59,7 +58,6 @@ import static org.apache.pulsar.client.api.Schema.STRING;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for using PulsarSink writing to a Pulsar cluster. */
-@Tag("org.apache.flink.testutils.junit.FailsOnJava11")
 class PulsarSinkITCase {
 
     /** Integration test based on the connector testing framework. */

--- a/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/PulsarSourceITCase.java
+++ b/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/PulsarSourceITCase.java
@@ -34,7 +34,6 @@ import org.apache.flink.connector.testframe.testsuites.SourceTestSuiteBase;
 import org.apache.flink.streaming.api.CheckpointingMode;
 
 import org.apache.pulsar.client.api.SubscriptionType;
-import org.junit.jupiter.api.Tag;
 
 import static org.apache.flink.streaming.api.CheckpointingMode.EXACTLY_ONCE;
 
@@ -42,7 +41,6 @@ import static org.apache.flink.streaming.api.CheckpointingMode.EXACTLY_ONCE;
  * Unit test class for {@link PulsarSource}. Used for {@link SubscriptionType#Exclusive}
  * subscription.
  */
-@Tag("org.apache.flink.testutils.junit.FailsOnJava11")
 class PulsarSourceITCase extends SourceTestSuiteBase<String> {
 
     // Defines test environment on Flink MiniCluster

--- a/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/sink/PulsarSinkTestContext.java
+++ b/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/sink/PulsarSinkTestContext.java
@@ -28,9 +28,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.util.Collections.singletonList;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_MEMORY_LIMIT_BYTES;
 import static org.apache.flink.connector.pulsar.sink.PulsarSinkOptions.PULSAR_BATCHING_MAX_MESSAGES;
 import static org.apache.flink.connector.pulsar.sink.writer.router.TopicRoutingMode.ROUND_ROBIN;
 import static org.apache.flink.connector.pulsar.testutils.PulsarTestCommonUtils.toDeliveryGuarantee;
+import static org.apache.pulsar.client.api.SizeUnit.MEGA_BYTES;
 
 /**
  * Common sink test context for the pulsar based tests. We use the string text as the basic send
@@ -74,7 +76,8 @@ public abstract class PulsarSinkTestContext extends PulsarTestContext<String>
                         .setDeliveryGuarantee(guarantee)
                         .setSerializationSchema(schema)
                         .enableSchemaEvolution()
-                        .setConfig(PULSAR_BATCHING_MAX_MESSAGES, 4);
+                        .setConfig(PULSAR_BATCHING_MAX_MESSAGES, 4)
+                        .setConfig(PULSAR_MEMORY_LIMIT_BYTES, MEGA_BYTES.toBytes(64));
         if (creatTopic()) {
             builder.setTopics(topics).setTopicRoutingMode(ROUND_ROBIN);
         } else {

--- a/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/source/PulsarSourceTestContext.java
+++ b/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/source/PulsarSourceTestContext.java
@@ -40,8 +40,10 @@ import java.util.stream.IntStream;
 
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_MEMORY_LIMIT_BYTES;
 import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_PARTITION_DISCOVERY_INTERVAL_MS;
 import static org.apache.pulsar.client.api.RegexSubscriptionMode.AllTopics;
+import static org.apache.pulsar.client.api.SizeUnit.MEGA_BYTES;
 
 /**
  * Common source test context for the pulsar based tests. We use the string text as the basic send
@@ -66,7 +68,8 @@ public abstract class PulsarSourceTestContext extends PulsarTestContext<String>
                         .setAdminUrl(operator.adminUrl())
                         .setTopicPattern(topicPattern(), AllTopics)
                         .setSubscriptionName(subscriptionName())
-                        .setConfig(PULSAR_PARTITION_DISCOVERY_INTERVAL_MS, DISCOVERY_INTERVAL);
+                        .setConfig(PULSAR_PARTITION_DISCOVERY_INTERVAL_MS, DISCOVERY_INTERVAL)
+                        .setConfig(PULSAR_MEMORY_LIMIT_BYTES, MEGA_BYTES.toBytes(64));
 
         // Set extra configuration for source builder.
         setSourceBuilder(builder);


### PR DESCRIPTION
This is working in progress PR for testing if we have supported Java 11 by changing the Netty allocator type to heap instead of direct buffer memory.