### PR TITLE
[FLINK-28959][Stream] Add retry and rate limit for admin request. Use binary protocol for topic filtering.

### DIFF
--- a/docs/layouts/shortcodes/generated/pulsar_admin_configuration.html
+++ b/docs/layouts/shortcodes/generated/pulsar_admin_configuration.html
@@ -33,10 +33,28 @@
             <td>The server response read timeout (in ms) for the PulsarAdmin client for any request.</td>
         </tr>
         <tr>
+            <td><h5>pulsar.admin.requestRates</h5></td>
+            <td style="word-wrap: break-word;">5</td>
+            <td>Integer</td>
+            <td>It will add ratelimit for PulsarAdmin metadata requests, stands for requests per second.</td>
+        </tr>
+        <tr>
+            <td><h5>pulsar.admin.requestRetries</h5></td>
+            <td style="word-wrap: break-word;">5</td>
+            <td>Integer</td>
+            <td>For PulsarAdmin request, it will retry until we get a success response, fail if we exhausted retry count.</td>
+        </tr>
+        <tr>
             <td><h5>pulsar.admin.requestTimeout</h5></td>
             <td style="word-wrap: break-word;">300000</td>
             <td>Integer</td>
             <td>The server request timeout (in ms) for the PulsarAdmin client for any request.</td>
+        </tr>
+        <tr>
+            <td><h5>pulsar.admin.requestWaitMillis</h5></td>
+            <td style="word-wrap: break-word;">3000</td>
+            <td>Long</td>
+            <td>For PulsarAdmin request, We will sleep the given time before retrying the failed request.</td>
         </tr>
     </tbody>
 </table>

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/config/PulsarAdminProxyBuilder.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/config/PulsarAdminProxyBuilder.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.common.config;
+
+import org.apache.flink.connector.pulsar.common.handler.PulsarAdminInvocationHandler;
+
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.internal.PulsarAdminBuilderImpl;
+import org.apache.pulsar.client.admin.internal.http.AsyncHttpConnector;
+import org.apache.pulsar.client.api.PulsarClientException;
+
+import java.lang.reflect.Proxy;
+
+/**
+ * {@link org.apache.pulsar.client.admin.PulsarAdminBuilder} didn't expose all the configurations to
+ * end user. We have to extend the default builder method for adding extra configurations.
+ */
+public class PulsarAdminProxyBuilder extends PulsarAdminBuilderImpl {
+
+    private final PulsarConfiguration configuration;
+
+    public PulsarAdminProxyBuilder(PulsarConfiguration configuration) {
+        this.configuration = configuration;
+    }
+
+    /**
+     * This is used by the internal implementation of {@link AsyncHttpConnector} to set the max
+     * allowed number of request threads.
+     */
+    public void numIoThreads(int numIoThreads) {
+        conf.setNumIoThreads(numIoThreads);
+    }
+
+    /**
+     * Wrap the pulsar admin interface into a proxy instance which can retry the request and limit
+     * the request rate.
+     */
+    @Override
+    public PulsarAdmin build() throws PulsarClientException {
+        PulsarAdminInvocationHandler handler =
+                new PulsarAdminInvocationHandler(super.build(), configuration);
+        return (PulsarAdmin)
+                Proxy.newProxyInstance(
+                        PulsarAdmin.class.getClassLoader(),
+                        new Class[] {PulsarAdmin.class},
+                        handler);
+    }
+}

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/config/PulsarClientFactory.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/config/PulsarClientFactory.java
@@ -22,7 +22,6 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.configuration.ConfigOption;
 
 import org.apache.pulsar.client.admin.PulsarAdmin;
-import org.apache.pulsar.client.admin.PulsarAdminBuilder;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.AuthenticationFactory;
 import org.apache.pulsar.client.api.ClientBuilder;
@@ -193,7 +192,7 @@ public final class PulsarClientFactory {
      */
     public static PulsarAdmin createAdmin(PulsarConfiguration configuration)
             throws PulsarClientException {
-        PulsarAdminBuilder builder = PulsarAdmin.builder();
+        PulsarAdminProxyBuilder builder = new PulsarAdminProxyBuilder(configuration);
 
         // Create the authentication instance for the Pulsar client.
         builder.authentication(createAuthentication(configuration));
@@ -223,6 +222,7 @@ public final class PulsarClientFactory {
                 PULSAR_REQUEST_TIMEOUT, v -> builder.requestTimeout(v, MILLISECONDS));
         configuration.useOption(
                 PULSAR_AUTO_CERT_REFRESH_TIME, v -> builder.autoCertRefreshTime(v, MILLISECONDS));
+        configuration.useOption(PULSAR_NUM_IO_THREADS, builder::numIoThreads);
 
         return builder.build();
     }

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/config/PulsarOptions.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/config/PulsarOptions.java
@@ -27,6 +27,7 @@ import org.apache.flink.configuration.description.Description;
 
 import org.apache.pulsar.client.api.ProxyProtocol;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -627,4 +628,29 @@ public final class PulsarOptions {
                     .defaultValue(300000)
                     .withDescription(
                             "The auto cert refresh time (in ms) if Pulsar admin supports TLS authentication.");
+
+    // These config options below are passing to PulsarAdminInvocationHandler.
+    // A wrapper for PulsarAdmin.
+
+    public static final ConfigOption<Integer> PULSAR_ADMIN_REQUEST_RETRIES =
+            ConfigOptions.key(ADMIN_CONFIG_PREFIX + "requestRetries")
+                    .intType()
+                    .defaultValue(5)
+                    .withDescription(
+                            "For PulsarAdmin request, it will retry until we get a success response,"
+                                    + " fail if we exhausted retry count.");
+
+    public static final ConfigOption<Long> PULSAR_ADMIN_REQUEST_WAIT_MILLIS =
+            ConfigOptions.key(ADMIN_CONFIG_PREFIX + "requestWaitMillis")
+                    .longType()
+                    .defaultValue(Duration.ofSeconds(3).toMillis())
+                    .withDescription(
+                            "For PulsarAdmin request, We will sleep the given time before retrying the failed request.");
+
+    public static final ConfigOption<Integer> PULSAR_ADMIN_REQUEST_RATES =
+            ConfigOptions.key(ADMIN_CONFIG_PREFIX + "requestRates")
+                    .intType()
+                    .defaultValue(5)
+                    .withDescription(
+                            "It will add ratelimit for PulsarAdmin metadata requests, stands for requests per second.");
 }

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/handler/PulsarAdminInvocationHandler.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/handler/PulsarAdminInvocationHandler.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.common.handler;
+
+import org.apache.flink.connector.pulsar.common.config.PulsarConfiguration;
+
+import org.apache.flink.shaded.guava30.com.google.common.util.concurrent.RateLimiter;
+
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.admin.PulsarAdminException.NotFoundException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_ADMIN_REQUEST_RATES;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_ADMIN_REQUEST_RETRIES;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_ADMIN_REQUEST_WAIT_MILLIS;
+import static org.apache.flink.shaded.guava30.com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
+
+/** A wrapper which wraps the {@link PulsarAdmin} with request retry and rate limit support. */
+public class PulsarAdminInvocationHandler implements InvocationHandler {
+    private static final Logger LOG = LoggerFactory.getLogger(PulsarAdminInvocationHandler.class);
+
+    @SuppressWarnings("java:S3077")
+    private static volatile RateLimiter rateLimiter;
+
+    private final PulsarAdmin admin;
+    private final int retryTimes;
+    private final long waitMillis;
+    private final int requestRates;
+    private final Map<String, Object> handlers;
+
+    public PulsarAdminInvocationHandler(PulsarAdmin admin, PulsarConfiguration configuration) {
+        this.admin = admin;
+        this.retryTimes = configuration.get(PULSAR_ADMIN_REQUEST_RETRIES);
+        this.waitMillis = configuration.get(PULSAR_ADMIN_REQUEST_WAIT_MILLIS);
+        this.requestRates = configuration.get(PULSAR_ADMIN_REQUEST_RATES);
+        this.handlers = new ConcurrentHashMap<>();
+    }
+
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        Class<?> returnType = method.getReturnType();
+
+        // No need to proxy the void return type.
+        // The non-interface type is not able to proxy.
+        if (returnType.equals(Void.TYPE) || !returnType.isInterface()) {
+            return method.invoke(admin, args);
+        }
+
+        String methodName = method.getName();
+        if (handlers.containsKey(methodName)) {
+            return handlers.get(methodName);
+        }
+
+        Object handler =
+                Proxy.newProxyInstance(
+                        Thread.currentThread().getContextClassLoader(),
+                        new Class[] {returnType},
+                        new RequestHandler(method.invoke(admin, args)));
+        this.handlers.put(methodName, handler);
+
+        return handler;
+    }
+
+    /** A proxy handler with retry support for all the admin request. */
+    @SuppressWarnings({"java:S1193", "java:S1181", "java:S3776", "java:S112"})
+    private class RequestHandler implements InvocationHandler {
+
+        private final Object handler;
+
+        public RequestHandler(Object handler) {
+            this.handler = handler;
+        }
+
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+            return doInvoke(method, args, retryTimes);
+        }
+
+        private Object doInvoke(Method method, Object[] args, int remainingTimes) throws Throwable {
+            while (true) {
+                // Make sure the request is allowed in the given rates.
+                requestRateLimit(requestRates);
+
+                try {
+                    return method.invoke(handler, args);
+                } catch (InvocationTargetException e) {
+                    Throwable throwable = e.getTargetException();
+                    if (throwable instanceof NotFoundException) {
+                        // No need to retry on such exceptions.
+                        throw throwable;
+                    } else if (throwable instanceof PulsarAdminException) {
+                        remainingTimes--;
+                        LOG.warn("Request error in Admin API, remain times: {}", remainingTimes, e);
+                        if (remainingTimes == 0) {
+                            throw throwable;
+                        } else {
+                            // Sleep for the given times before executing the next query.
+                            sleepUninterruptibly(waitMillis, MILLISECONDS);
+                        }
+                    } else {
+                        throw throwable;
+                    }
+                }
+            }
+        }
+    }
+
+    /** Request a global ratelimit which limits the total admin API request rates. */
+    private static void requestRateLimit(int requestRates) {
+        if (rateLimiter == null) {
+            synchronized (PulsarAdminInvocationHandler.class) {
+                if (rateLimiter == null) {
+                    rateLimiter = RateLimiter.create(requestRates);
+                }
+            }
+        }
+
+        rateLimiter.acquire();
+    }
+}

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/router/KeyHashTopicRouter.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/router/KeyHashTopicRouter.java
@@ -30,7 +30,7 @@ import org.apache.pulsar.client.impl.Hash;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
-import static org.apache.flink.shaded.guava30.com.google.common.base.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.pulsar.client.util.MathUtils.signSafeMod;
 
 /**

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/router/RoundRobinTopicRouter.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/router/RoundRobinTopicRouter.java
@@ -27,7 +27,7 @@ import org.apache.flink.util.Preconditions;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static org.apache.flink.shaded.guava30.com.google.common.base.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkArgument;
 
 /**
  * If you choose the {@link TopicRoutingMode#ROUND_ROBIN} policy, we would use this implementation.

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/PulsarSourceBuilder.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/PulsarSourceBuilder.java
@@ -210,6 +210,10 @@ public final class PulsarSourceBuilder<OUT> {
      * Set a topic pattern to consume from the java regex str. You can set topics once either with
      * {@link #setTopics} or {@link #setTopicPattern} in this builder.
      *
+     * <p>Remember that we will only subscribe to one tenant and one namespace by using regular
+     * expression. If you didn't provide the tenant and namespace in the given topic pattern. We
+     * will use default one instead.
+     *
      * @param topicsPattern the pattern of the topic name to consume from.
      * @return this PulsarSourceBuilder.
      */
@@ -221,6 +225,10 @@ public final class PulsarSourceBuilder<OUT> {
      * Set a topic pattern to consume from the java {@link Pattern}. You can set topics once either
      * with {@link #setTopics} or {@link #setTopicPattern} in this builder.
      *
+     * <p>Remember that we will only subscribe to one tenant and one namespace by using regular
+     * expression. If you didn't provide the tenant and namespace in the given topic pattern. We
+     * will use default one instead.
+     *
      * @param topicsPattern the pattern of the topic name to consume from.
      * @return this PulsarSourceBuilder.
      */
@@ -231,6 +239,10 @@ public final class PulsarSourceBuilder<OUT> {
     /**
      * Set a topic pattern to consume from the java regex str. You can set topics once either with
      * {@link #setTopics} or {@link #setTopicPattern} in this builder.
+     *
+     * <p>Remember that we will only subscribe to one tenant and one namespace by using regular
+     * expression. If you didn't provide the tenant and namespace in the given topic pattern. We
+     * will use default one instead.
      *
      * @param topicsPattern the pattern of the topic name to consume from.
      * @param regexSubscriptionMode The topic filter for regex subscription.
@@ -244,6 +256,10 @@ public final class PulsarSourceBuilder<OUT> {
     /**
      * Set a topic pattern to consume from the java {@link Pattern}. You can set topics once either
      * with {@link #setTopics} or {@link #setTopicPattern} in this builder.
+     *
+     * <p>Remember that we will only subscribe to one tenant and one namespace by using regular
+     * expression. If you didn't provide the tenant and namespace in the given topic pattern. We
+     * will use default one instead.
      *
      * @param topicsPattern the pattern of the topic name to consume from.
      * @param regexSubscriptionMode When subscribing to a topic using a regular expression, you can

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/subscriber/PulsarSubscriber.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/subscriber/PulsarSubscriber.java
@@ -25,6 +25,7 @@ import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicPartition;
 import org.apache.flink.connector.pulsar.source.enumerator.topic.range.RangeGenerator;
 
 import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.RegexSubscriptionMode;
 
 import java.io.Serializable;
@@ -61,9 +62,10 @@ public interface PulsarSubscriber extends Serializable {
     /**
      * Initialize the topic subscriber.
      *
+     * @param client The client interface for querying the topics by regex pattern.
      * @param admin The admin interface used to retrieve subscribed topic partitions.
      */
-    void open(PulsarAdmin admin);
+    void open(PulsarClient client, PulsarAdmin admin);
 
     // ----------------- factory methods --------------
 

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/subscriber/impl/BasePulsarSubscriber.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/subscriber/impl/BasePulsarSubscriber.java
@@ -20,32 +20,44 @@ package org.apache.flink.connector.pulsar.source.enumerator.subscriber.impl;
 
 import org.apache.flink.connector.pulsar.source.enumerator.subscriber.PulsarSubscriber;
 import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicMetadata;
-import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicNameUtils;
 import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicPartition;
 import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicRange;
 import org.apache.flink.connector.pulsar.source.enumerator.topic.range.RangeGenerator;
 
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
 
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.apache.pulsar.common.partition.PartitionedTopicMetadata.NON_PARTITIONED;
 
 /** PulsarSubscriber abstract class to simplify Pulsar admin related operations. */
 public abstract class BasePulsarSubscriber implements PulsarSubscriber {
     private static final long serialVersionUID = 2053021503331058888L;
 
+    // Pulsar doesn't allow converting a non-partitioned topic into a partitioned topic.
+    // So we can just cache all the non-partitioned topics here for speeding up the query time.
+    private static final Set<String> NON_PARTITIONED_TOPICS = ConcurrentHashMap.newKeySet();
+
+    protected transient PulsarClient client;
     protected transient PulsarAdmin admin;
 
-    protected TopicMetadata queryTopicMetadata(String topicName) throws PulsarAdminException {
-        // Drop the complete topic name for a clean partitioned topic name.
-        String completeTopicName = TopicNameUtils.topicName(topicName);
+    protected TopicMetadata queryTopicMetadata(String topic) throws PulsarAdminException {
+        if (NON_PARTITIONED_TOPICS.contains(topic)) {
+            return new TopicMetadata(topic, NON_PARTITIONED);
+        }
+
         try {
-            PartitionedTopicMetadata metadata =
-                    admin.topics().getPartitionedTopicMetadata(completeTopicName);
-            return new TopicMetadata(topicName, metadata.partitions);
+            PartitionedTopicMetadata metadata = admin.topics().getPartitionedTopicMetadata(topic);
+            if (metadata.partitions == NON_PARTITIONED) {
+                NON_PARTITIONED_TOPICS.add(topic);
+            }
+            return new TopicMetadata(topic, metadata.partitions);
         } catch (PulsarAdminException e) {
             if (e.getStatusCode() == 404) {
                 // Return null for skipping the topic metadata query.
@@ -82,7 +94,8 @@ public abstract class BasePulsarSubscriber implements PulsarSubscriber {
     }
 
     @Override
-    public void open(PulsarAdmin admin) {
+    public void open(PulsarClient client, PulsarAdmin admin) {
+        this.client = client;
         this.admin = admin;
     }
 }

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/subscriber/impl/TopicListSubscriber.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/subscriber/impl/TopicListSubscriber.java
@@ -64,7 +64,7 @@ public class TopicListSubscriber extends BasePulsarSubscriber {
             TopicName topicName = TopicName.get(partition);
             String name = topicName.getPartitionedTopicName();
             int index = topicName.getPartitionIndex();
-            TopicMetadata metadata = queryTopicMetadata(name);
+            TopicMetadata metadata = queryTopicMetadata(partition);
             if (metadata != null) {
                 List<TopicRange> ranges = generator.range(metadata, parallelism);
                 results.add(new TopicPartition(name, index, ranges));

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/subscriber/impl/TopicPatternSubscriber.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/subscriber/impl/TopicPatternSubscriber.java
@@ -21,28 +21,34 @@ package org.apache.flink.connector.pulsar.source.enumerator.subscriber.impl;
 import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicPartition;
 import org.apache.flink.connector.pulsar.source.enumerator.topic.range.RangeGenerator;
 
+import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.RegexSubscriptionMode;
+import org.apache.pulsar.client.impl.LookupService;
+import org.apache.pulsar.client.impl.PulsarClientImpl;
+import org.apache.pulsar.common.api.proto.CommandGetTopicsOfNamespace.Mode;
+import org.apache.pulsar.common.lookup.GetTopicsResult;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.topics.TopicList;
 
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 import java.util.regex.Pattern;
 
 import static org.apache.flink.connector.pulsar.source.enumerator.topic.TopicNameUtils.isInternal;
-import static org.apache.flink.connector.pulsar.source.enumerator.topic.TopicNameUtils.topicName;
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
-/** Subscribe to matching topics based on topic pattern. */
+/** Subscribe to matching topics based on the topic pattern. */
 public class TopicPatternSubscriber extends BasePulsarSubscriber {
     private static final long serialVersionUID = 3307710093243745104L;
 
     private final Pattern shortenedPattern;
     private final String namespace;
-    private final RegexSubscriptionMode subscriptionMode;
+    private final Mode subscriptionMode;
 
     public TopicPatternSubscriber(Pattern topicPattern, RegexSubscriptionMode subscriptionMode) {
-        this.subscriptionMode = subscriptionMode;
         String pattern = topicPattern.toString();
         this.shortenedPattern =
                 pattern.contains("://") ? Pattern.compile(pattern.split("://")[1]) : topicPattern;
@@ -52,50 +58,78 @@ public class TopicPatternSubscriber extends BasePulsarSubscriber {
         TopicName destination = TopicName.get(topicPattern.pattern());
         NamespaceName namespaceName = destination.getNamespaceObject();
         this.namespace = namespaceName.toString();
+        this.subscriptionMode = convertRegexSubscriptionMode(subscriptionMode);
     }
 
     @Override
     public Set<TopicPartition> getSubscribedTopicPartitions(
             RangeGenerator generator, int parallelism) throws Exception {
-        // This method will query a set of existed topic partitions.
-        List<String> partitions = admin.namespaces().getTopics(namespace);
-        Set<String> results = new HashSet<>(partitions.size());
+        Set<String> topics = queryTopicsByInternalProtocols();
+        return createTopicPartitions(topics, generator, parallelism);
+    }
 
-        for (String partition : partitions) {
-            String topic = topicName(partition);
-            if (matchesSubscriptionMode(topic)
-                    && !isInternal(topic)
-                    && matchesTopicPattern(topic)) {
-                results.add(topic);
+    /**
+     * We reuse this internal protocol in the Pulsar client for achieving the same behavior as
+     * directly using the client to consume the topic pattern.
+     */
+    private Set<String> queryTopicsByInternalProtocols() throws PulsarClientException {
+        checkNotNull(client, "This subscriber doesn't initialize properly.");
+
+        LookupService lookupService = ((PulsarClientImpl) client).getLookup();
+        NamespaceName namespaceName = NamespaceName.get(namespace);
+        try {
+            // Pulsar 2.11.0 can filter regular expression on broker, but it has a bug which can
+            // only be used for wildcard filtering.
+            String queryPattern = shortenedPattern.toString();
+            if (!queryPattern.endsWith(".*")) {
+                queryPattern = null;
             }
-        }
 
-        return createTopicPartitions(results, generator, parallelism);
+            GetTopicsResult topicsResult =
+                    lookupService
+                            .getTopicsUnderNamespace(
+                                    namespaceName, subscriptionMode, queryPattern, null)
+                            .get();
+            List<String> topics = topicsResult.getTopics();
+            Set<String> results = new HashSet<>(topics.size());
+
+            // The regular expression filter may not be enabled in broker.
+            // Add the filter here if the result is not filtered.
+            for (String topic : topics) {
+                if (!isInternal(topic)
+                        && (topicsResult.isFiltered() || matchesTopicPattern(topic))) {
+                    results.add(topic);
+                }
+            }
+
+            return results;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarClientException(e);
+        } catch (ExecutionException e) {
+            throw PulsarClientException.unwrap(e);
+        }
     }
 
     /**
      * If the topic matches 'topicsPattern'. This method is in the PulsarClient, and it's removed
-     * since 2.11.0 release. We keep the method here.
+     * since 2.11.0 release. We keep the method here. It's copied from {@link
+     * TopicList#filterTopics(List, String)}.
      */
     private boolean matchesTopicPattern(String topic) {
         String shortenedTopic = topic.split("://")[1];
         return shortenedPattern.matcher(shortenedTopic).matches();
     }
 
-    /**
-     * Filter the topic by regex subscription mode. This logic is the same as pulsar consumer's
-     * regex subscription.
-     */
-    private boolean matchesSubscriptionMode(String topic) {
-        TopicName topicName = TopicName.get(topic);
-        // Filter the topic persistence.
+    /** Convert the subscription mode into the internal binary protocol. */
+    private Mode convertRegexSubscriptionMode(RegexSubscriptionMode subscriptionMode) {
         switch (subscriptionMode) {
-            case PersistentOnly:
-                return topicName.isPersistent();
-            case NonPersistentOnly:
-                return !topicName.isPersistent();
             case AllTopics:
-                return true;
+                return Mode.ALL;
+            case PersistentOnly:
+                return Mode.PERSISTENT;
+            case NonPersistentOnly:
+                return Mode.NON_PERSISTENT;
             default:
                 throw new IllegalArgumentException(
                         "We don't support such subscription mode " + subscriptionMode);

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/topic/TopicNameUtils.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/topic/TopicNameUtils.java
@@ -24,7 +24,6 @@ import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableList;
 
 import org.apache.pulsar.common.naming.TopicName;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -66,10 +65,10 @@ public final class TopicNameUtils {
         return TopicName.get(topic).isPartitioned();
     }
 
-    /** Merge the same topics into one topic. */
+    /** Merge the same topics or partitions into one topic. */
     public static List<String> distinctTopics(List<String> topics) {
         Set<String> fullTopics = new HashSet<>();
-        Map<String, List<Integer>> partitionedTopics = new HashMap<>();
+        Map<String, Set<Integer>> partitionedTopics = new HashMap<>();
 
         for (String topic : topics) {
             TopicName topicName = TopicName.get(topic);
@@ -79,16 +78,16 @@ public final class TopicNameUtils {
                 fullTopics.add(partitionedTopicName);
                 partitionedTopics.remove(partitionedTopicName);
             } else if (!fullTopics.contains(partitionedTopicName)) {
-                List<Integer> partitionIds =
+                Set<Integer> partitionIds =
                         partitionedTopics.computeIfAbsent(
-                                partitionedTopicName, k -> new ArrayList<>());
+                                partitionedTopicName, k -> new HashSet<>());
                 partitionIds.add(topicName.getPartitionIndex());
             }
         }
 
         ImmutableList.Builder<String> builder = ImmutableList.<String>builder().addAll(fullTopics);
 
-        for (Map.Entry<String, List<Integer>> topicSet : partitionedTopics.entrySet()) {
+        for (Map.Entry<String, Set<Integer>> topicSet : partitionedTopics.entrySet()) {
             String topicName = topicSet.getKey();
             for (Integer partitionId : topicSet.getValue()) {
                 builder.add(topicNameWithPartition(topicName, partitionId));

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/PulsarPartitionSplitReader.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/PulsarPartitionSplitReader.java
@@ -95,8 +95,8 @@ public class PulsarPartitionSplitReader
     private static final Logger LOG = LoggerFactory.getLogger(PulsarPartitionSplitReader.class);
 
     private final PulsarClient pulsarClient;
-    @VisibleForTesting final PulsarAdmin pulsarAdmin;
-    @VisibleForTesting final SourceConfiguration sourceConfiguration;
+    private final PulsarAdmin pulsarAdmin;
+    private final SourceConfiguration sourceConfiguration;
     private final Schema<byte[]> schema;
     private final PulsarCrypto pulsarCrypto;
     private final SourceReaderMetricGroup metricGroup;
@@ -353,5 +353,10 @@ public class PulsarPartitionSplitReader
             group.gauge(TOTAL_ACKS_FAILED, stats::getTotalAcksFailed);
             group.gauge(MSG_NUM_IN_RECEIVER_QUEUE, stats::getMsgNumInReceiverQueue);
         }
+    }
+
+    @VisibleForTesting
+    String getSubscriptionName() {
+        return sourceConfiguration.getSubscriptionName();
     }
 }

--- a/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/common/handler/PulsarAdminInvocationHandlerTest.java
+++ b/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/common/handler/PulsarAdminInvocationHandlerTest.java
@@ -1,0 +1,309 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.common.handler;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.pulsar.sink.config.SinkConfiguration;
+
+import org.apache.pulsar.client.admin.Bookies;
+import org.apache.pulsar.client.admin.BrokerStats;
+import org.apache.pulsar.client.admin.Brokers;
+import org.apache.pulsar.client.admin.Clusters;
+import org.apache.pulsar.client.admin.Functions;
+import org.apache.pulsar.client.admin.Lookup;
+import org.apache.pulsar.client.admin.Namespaces;
+import org.apache.pulsar.client.admin.NonPersistentTopics;
+import org.apache.pulsar.client.admin.Packages;
+import org.apache.pulsar.client.admin.Properties;
+import org.apache.pulsar.client.admin.ProxyStats;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.admin.PulsarAdminException.NotFoundException;
+import org.apache.pulsar.client.admin.ResourceGroups;
+import org.apache.pulsar.client.admin.ResourceQuotas;
+import org.apache.pulsar.client.admin.Schemas;
+import org.apache.pulsar.client.admin.Sink;
+import org.apache.pulsar.client.admin.Sinks;
+import org.apache.pulsar.client.admin.Source;
+import org.apache.pulsar.client.admin.Sources;
+import org.apache.pulsar.client.admin.Tenants;
+import org.apache.pulsar.client.admin.TopicPolicies;
+import org.apache.pulsar.client.admin.Topics;
+import org.apache.pulsar.client.admin.Transactions;
+import org.apache.pulsar.client.admin.Worker;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_ADMIN_REQUEST_RATES;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_ADMIN_REQUEST_RETRIES;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_ADMIN_REQUEST_WAIT_MILLIS;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** Unit test of {@link PulsarAdminInvocationHandler}. */
+class PulsarAdminInvocationHandlerTest {
+
+    @Test
+    void retryWithFixedTimesOnRequestFailure() {
+        int retryTimes = 5 + ThreadLocalRandom.current().nextInt(5);
+        String errorMsg = "Always failed with reason: " + randomAlphanumeric(10);
+
+        PulsarAdminTestImpl admin = new PulsarAdminTestImpl(errorMsg);
+
+        Configuration configuration = new Configuration();
+        configuration.set(PULSAR_ADMIN_REQUEST_RETRIES, retryTimes);
+        configuration.set(PULSAR_ADMIN_REQUEST_WAIT_MILLIS, 50L);
+        configuration.set(PULSAR_ADMIN_REQUEST_RATES, 1000);
+        SinkConfiguration sinkConfiguration = new SinkConfiguration(configuration);
+
+        PulsarAdminInvocationHandler handler =
+                new PulsarAdminInvocationHandler(admin, sinkConfiguration);
+
+        PulsarAdmin proxyAdmin =
+                (PulsarAdmin)
+                        Proxy.newProxyInstance(
+                                PulsarAdmin.class.getClassLoader(),
+                                new Class[] {PulsarAdmin.class},
+                                handler);
+
+        assertThatThrownBy(() -> proxyAdmin.lookups().lookupPartitionedTopic("aa"))
+                .isInstanceOf(PulsarAdminException.class)
+                .hasMessage(errorMsg);
+        assertEquals(retryTimes, admin.lookup.callingTimes());
+    }
+
+    @Test
+    void didNotRetryOnNotFoundException() {
+        PulsarAdminTestImpl admin = new PulsarAdminTestImpl("not found");
+
+        PulsarAdminInvocationHandler handler =
+                new PulsarAdminInvocationHandler(admin, new SinkConfiguration(new Configuration()));
+
+        PulsarAdmin proxyAdmin =
+                (PulsarAdmin)
+                        Proxy.newProxyInstance(
+                                PulsarAdmin.class.getClassLoader(),
+                                new Class[] {PulsarAdmin.class},
+                                handler);
+
+        assertThatThrownBy(() -> proxyAdmin.lookups().lookupTopic("some"))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("not found");
+        assertEquals(1, admin.lookup.callingTimes());
+    }
+
+    /** Test implementation for PulsarAdmin. */
+    private static final class PulsarAdminTestImpl implements PulsarAdmin {
+
+        private final LookupTestImpl lookup;
+
+        private PulsarAdminTestImpl(String errorMsg) {
+            this.lookup = new LookupTestImpl(errorMsg);
+        }
+
+        @Override
+        public Clusters clusters() {
+            throw new UnsupportedOperationException("We didn't support this method in test.");
+        }
+
+        @Override
+        public Brokers brokers() {
+            throw new UnsupportedOperationException("We didn't support this method in test.");
+        }
+
+        @Override
+        public Tenants tenants() {
+            throw new UnsupportedOperationException("We didn't support this method in test.");
+        }
+
+        @Override
+        public ResourceGroups resourcegroups() {
+            throw new UnsupportedOperationException("We didn't support this method in test.");
+        }
+
+        @Override
+        public Properties properties() {
+            throw new UnsupportedOperationException("We didn't support this method in test.");
+        }
+
+        @Override
+        public Namespaces namespaces() {
+            throw new UnsupportedOperationException("We didn't support this method in test.");
+        }
+
+        @Override
+        public Topics topics() {
+            throw new UnsupportedOperationException("We didn't support this method in test.");
+        }
+
+        @Override
+        public TopicPolicies topicPolicies() {
+            throw new UnsupportedOperationException("We didn't support this method in test.");
+        }
+
+        @Override
+        public TopicPolicies topicPolicies(boolean isGlobal) {
+            throw new UnsupportedOperationException("We didn't support this method in test.");
+        }
+
+        @Override
+        public Bookies bookies() {
+            throw new UnsupportedOperationException("We didn't support this method in test.");
+        }
+
+        @Override
+        public NonPersistentTopics nonPersistentTopics() {
+            throw new UnsupportedOperationException("We didn't support this method in test.");
+        }
+
+        @Override
+        public ResourceQuotas resourceQuotas() {
+            throw new UnsupportedOperationException("We didn't support this method in test.");
+        }
+
+        @Override
+        public Lookup lookups() {
+            lookup.resetTimes();
+            return lookup;
+        }
+
+        @Override
+        public Functions functions() {
+            throw new UnsupportedOperationException("We didn't support this method in test.");
+        }
+
+        @Override
+        public Source source() {
+            throw new UnsupportedOperationException("We didn't support this method in test.");
+        }
+
+        @Override
+        public Sources sources() {
+            throw new UnsupportedOperationException("We didn't support this method in test.");
+        }
+
+        @Override
+        public Sink sink() {
+            throw new UnsupportedOperationException("We didn't support this method in test.");
+        }
+
+        @Override
+        public Sinks sinks() {
+            throw new UnsupportedOperationException("We didn't support this method in test.");
+        }
+
+        @Override
+        public Worker worker() {
+            throw new UnsupportedOperationException("We didn't support this method in test.");
+        }
+
+        @Override
+        public BrokerStats brokerStats() {
+            throw new UnsupportedOperationException("We didn't support this method in test.");
+        }
+
+        @Override
+        public ProxyStats proxyStats() {
+            throw new UnsupportedOperationException("We didn't support this method in test.");
+        }
+
+        @Override
+        public String getServiceUrl() {
+            throw new UnsupportedOperationException("We didn't support this method in test.");
+        }
+
+        @Override
+        public Schemas schemas() {
+            throw new UnsupportedOperationException("We didn't support this method in test.");
+        }
+
+        @Override
+        public Packages packages() {
+            throw new UnsupportedOperationException("We didn't support this method in test.");
+        }
+
+        @Override
+        public Transactions transactions() {
+            throw new UnsupportedOperationException("We didn't support this method in test.");
+        }
+
+        @Override
+        public void close() {
+            throw new UnsupportedOperationException("We didn't support this method in test.");
+        }
+    }
+
+    /** Test implementation for Lookup. */
+    private static final class LookupTestImpl implements Lookup {
+
+        private final String errorMsg;
+        private int times;
+
+        private LookupTestImpl(String errorMsg) {
+            this.errorMsg = errorMsg;
+        }
+
+        @Override
+        public String lookupTopic(String topic) throws PulsarAdminException {
+            times++;
+            throw new NotFoundException(
+                    new IllegalArgumentException("not found"), "not found", 404);
+        }
+
+        @Override
+        public CompletableFuture<String> lookupTopicAsync(String topic) {
+            throw new UnsupportedOperationException("We didn't support this method in test.");
+        }
+
+        @Override
+        public Map<String, String> lookupPartitionedTopic(String topic)
+                throws PulsarAdminException {
+            times++;
+            throw new PulsarAdminException(errorMsg);
+        }
+
+        @Override
+        public CompletableFuture<Map<String, String>> lookupPartitionedTopicAsync(String topic) {
+            throw new UnsupportedOperationException("We didn't support this method in test.");
+        }
+
+        @Override
+        public String getBundleRange(String topic) {
+            throw new UnsupportedOperationException("We didn't support this method in test.");
+        }
+
+        @Override
+        public CompletableFuture<String> getBundleRangeAsync(String topic) {
+            throw new UnsupportedOperationException("We didn't support this method in test.");
+        }
+
+        public int callingTimes() {
+            return times;
+        }
+
+        public void resetTimes() {
+            this.times = 0;
+        }
+    }
+}

--- a/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/enumerator/subscriber/PulsarSubscriberTest.java
+++ b/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/enumerator/subscriber/PulsarSubscriberTest.java
@@ -78,7 +78,7 @@ class PulsarSubscriberTest extends PulsarTestSuiteBase {
     @Test
     void topicListSubscriber() throws Exception {
         PulsarSubscriber subscriber = getTopicListSubscriber(Arrays.asList(topic1, topic2));
-        subscriber.open(operator().admin());
+        subscriber.open(operator().client(), operator().admin());
 
         Set<TopicPartition> topicPartitions =
                 subscriber.getSubscribedTopicPartitions(new FullRangeGenerator(), NUM_PARALLELISM);
@@ -97,7 +97,7 @@ class PulsarSubscriberTest extends PulsarTestSuiteBase {
         String partition = topicNameWithPartition(topic1, 2);
 
         PulsarSubscriber subscriber = getTopicListSubscriber(singletonList(partition));
-        subscriber.open(operator().admin());
+        subscriber.open(operator().client(), operator().admin());
 
         Set<TopicPartition> partitions =
                 subscriber.getSubscribedTopicPartitions(new FullRangeGenerator(), NUM_PARALLELISM);
@@ -109,7 +109,7 @@ class PulsarSubscriberTest extends PulsarTestSuiteBase {
     @Test
     void subscribeNonPartitionedTopicList() throws Exception {
         PulsarSubscriber subscriber = getTopicListSubscriber(singletonList(topic4));
-        subscriber.open(operator().admin());
+        subscriber.open(operator().client(), operator().admin());
 
         Set<TopicPartition> partitions =
                 subscriber.getSubscribedTopicPartitions(new FullRangeGenerator(), NUM_PARALLELISM);
@@ -125,7 +125,7 @@ class PulsarSubscriberTest extends PulsarTestSuiteBase {
                         Pattern.compile(
                                 "persistent://public/default/pulsar-subscriber-non-partitioned-topic.*?"),
                         AllTopics);
-        subscriber.open(operator().admin());
+        subscriber.open(operator().client(), operator().admin());
 
         Set<TopicPartition> topicPartitions =
                 subscriber.getSubscribedTopicPartitions(new FullRangeGenerator(), NUM_PARALLELISM);
@@ -144,7 +144,7 @@ class PulsarSubscriberTest extends PulsarTestSuiteBase {
                 getTopicPatternSubscriber(
                         Pattern.compile("persistent://public/default/pulsar-subscriber-topic.*?"),
                         AllTopics);
-        subscriber.open(operator().admin());
+        subscriber.open(operator().client(), operator().admin());
 
         Set<TopicPartition> topicPartitions =
                 subscriber.getSubscribedTopicPartitions(new FullRangeGenerator(), NUM_PARALLELISM);

--- a/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/reader/PulsarPartitionSplitReaderTest.java
+++ b/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/reader/PulsarPartitionSplitReaderTest.java
@@ -30,7 +30,6 @@ import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicPartition;
 import org.apache.flink.connector.pulsar.source.split.PulsarPartitionSplit;
 import org.apache.flink.connector.pulsar.testutils.PulsarTestSuiteBase;
 
-import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.impl.MessageIdImpl;
@@ -321,16 +320,17 @@ class PulsarPartitionSplitReaderTest extends PulsarTestSuiteBase {
 
         // Create the subscription and set the start position for this reader.
         // Remember not to use Consumer.seek(startPosition)
-        SourceConfiguration sourceConfiguration = reader.sourceConfiguration;
-        PulsarAdmin pulsarAdmin = reader.pulsarAdmin;
-        String subscriptionName = sourceConfiguration.getSubscriptionName();
-        List<String> subscriptions = pulsarAdmin.topics().getSubscriptions(topicName);
+        String subscriptionName = reader.getSubscriptionName();
+        List<String> subscriptions = operator().admin().topics().getSubscriptions(topicName);
         if (!subscriptions.contains(subscriptionName)) {
             // If this subscription is not available. Just create it.
-            pulsarAdmin.topics().createSubscription(topicName, subscriptionName, startPosition);
+            operator()
+                    .admin()
+                    .topics()
+                    .createSubscription(topicName, subscriptionName, startPosition);
         } else {
             // Reset the subscription if this is existed.
-            pulsarAdmin.topics().resetCursor(topicName, subscriptionName, startPosition);
+            operator().admin().topics().resetCursor(topicName, subscriptionName, startPosition);
         }
 
         // Accept the split and start consuming.


### PR DESCRIPTION
## Purpose of the change

This pull request reduce the topic metadata request by using a new protocol.
And introduce a common admin request proxy which can limit the request rates and retry the failed admin API request.

## Brief change log

- Expose the num of thread count to user.
- Add new `PulsarOptions.PULSAR_ADMIN_REQUEST_RETRIES`, `PulsarOptions.PULSAR_ADMIN_REQUEST_WAIT_MILLIS`, `PulsarOptions.PULSAR_ADMIN_REQUEST_RATES` options to end users.
- Proxy the admin API into `PulsarAdminInvocationHandler`.
- Change the implementation in `TopicPatternSubscriber`. Add a new binary protocol for improve the performance.
- Cache all the non-partitons topics in `BasePulsarSubscriber`.
- Fix the bug in `TopicNameUtils`, we forget to make the partitions distinct.
- Correct the partition id setting in `TopicPartition`. Since it has been exposed to end user, we need to make the logic more robust.

## Verifying this change

This change is already covered by existing tests, such as the test classes below:

- `PulsarSubscriberTest`
- `PulsarPartitionSplitReaderTest`
- `PulsarSourceITCase`

We also add new tests for the `PulsarAdminInvocationHandler`.

- `PulsarAdminInvocationHandlerTest`

## Significant changes

- [ ] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [x] New feature has been introduced
    - If yes, how is this documented? (docs)