### PR TITLE
[FLINK-31100][Stream] Support the short topic pattern subscriber on default tenant and namespace.

### DIFF
--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/subscriber/impl/TopicPatternSubscriber.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/subscriber/impl/TopicPatternSubscriber.java
@@ -49,15 +49,11 @@ public class TopicPatternSubscriber extends BasePulsarSubscriber {
     private final Mode subscriptionMode;
 
     public TopicPatternSubscriber(Pattern topicPattern, RegexSubscriptionMode subscriptionMode) {
-        String pattern = topicPattern.toString();
-        this.shortenedPattern =
-                pattern.contains("://") ? Pattern.compile(pattern.split("://")[1]) : topicPattern;
-
-        // Extract the namespace from topic pattern regex.
-        // If no namespace provided in the regex, we would directly use "default" as the namespace.
         TopicName destination = TopicName.get(topicPattern.pattern());
-        NamespaceName namespaceName = destination.getNamespaceObject();
-        this.namespace = namespaceName.toString();
+        String pattern = destination.toString();
+
+        this.shortenedPattern = Pattern.compile(pattern.split("://")[1]);
+        this.namespace = destination.getNamespaceObject().toString();
         this.subscriptionMode = convertRegexSubscriptionMode(subscriptionMode);
     }
 

--- a/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/runtime/container/PulsarContainerRuntime.java
+++ b/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/runtime/container/PulsarContainerRuntime.java
@@ -75,6 +75,8 @@ public class PulsarContainerRuntime implements PulsarRuntime {
         brokerConfigs.put("allowAutoTopicCreationType", "partitioned");
         brokerConfigs.put("defaultNumPartitions", "4");
         brokerConfigs.put("enableBrokerSideSubscriptionPatternEvaluation", "true");
+        brokerConfigs.put("brokerDeleteInactiveTopicsEnabled", "false");
+        brokerConfigs.put("enableNonPersistentTopics", "true");
     }
 
     public PulsarContainerRuntime bindWithFlinkContainer(GenericContainer<?> flinkContainer) {

--- a/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/runtime/remote/PulsarRemoteRuntime.java
+++ b/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/runtime/remote/PulsarRemoteRuntime.java
@@ -28,8 +28,12 @@ public class PulsarRemoteRuntime implements PulsarRuntime {
 
     @Override
     public PulsarRuntime withConfigs(Map<String, String> configs) {
-        throw new UnsupportedOperationException(
-                "We can't change the broker configs on a running instance.");
+        if (!configs.isEmpty()) {
+            throw new UnsupportedOperationException(
+                    "We can't change the broker configs on a running instance.");
+        }
+
+        return this;
     }
 
     @Override


### PR DESCRIPTION
## Purpose of the change

The connector can subscribe the topics by using regular expression. But it can't use any simple regex like `some.*`. Any regex should in `tenant/namespace/regex` format. Since Pulsar support simple topic name which live under `public` tenant and `default` namespace. I think it's awesome to support same ability in regex subscription.

## Brief change log

- Change the internal design of `TopicPatternSubscriber`. The regex will be convert into a full regex by using `TopicName`.

There is [a known bug](https://github.com/apache/pulsar/issues/19316) in Pulsar 2.11.0. We can't subscribe the non-persistent topics by using regex now. We also create [a JIRA ticket](https://issues.apache.org/jira/browse/FLINK-31107) for tracking this bug.

## Verifying this change

This change added tests and can be verified as follows:

- `PulsarSubscriberTest.simpleTopicPatternSubscriber`
- `PulsarSubscriberTest.topicPatternSubscriber`
- `PulsarSubscriberTest.subscribeNonPartitionedTopicPattern`

## Significant changes

- [ ] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [x] New feature has been introduced
    - If yes, how is this documented? (docs)
