### PR TITLE
[hotfix][Build] Adjust running time of nightly CI from weekly to daily.

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -19,7 +19,7 @@
 name: Nightly
 on:
   schedule:
-    - cron: "0 0 * * 0"
+    - cron: "0 0 * * *"
 jobs:
   compile_and_test:
     if: github.repository_owner == 'apache'


### PR DESCRIPTION
## Purpose of the change

*Adjust running time of nightly CI from weekly to daily.*

## Brief change log

- *change cron expression of nighty ci yaml.*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Significant changes

- [ ] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [ ] New feature has been introduced
    - If yes, how is this documented? (not applicable / docs / JavaDocs / not documented)
