### PR TITLE
[FLINK-31427][Table] Initial Catalog implementation with a new config model and schema conversion.

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -20,5 +20,6 @@
   </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/tools/releasing/shared" vcs="Git" />
   </component>
 </project>

--- a/flink-connector-pulsar/pom.xml
+++ b/flink-connector-pulsar/pom.xml
@@ -51,7 +51,15 @@ under the License.
 			<scope>provided</scope>
 		</dependency>
 
-		<!-- Formats -->
+		<!-- Projects depending on this project won't depend on flink-table-*. -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-api-java-bridge</artifactId>
+			<scope>provided</scope>
+			<optional>true</optional>
+		</dependency>
+
+		<!-- Formats, they are used in Table API. -->
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
@@ -63,6 +71,13 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-json</artifactId>
+			<scope>provided</scope>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-protobuf</artifactId>
 			<scope>provided</scope>
 			<optional>true</optional>
 		</dependency>

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/handler/PulsarAdminInvocationHandler.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/handler/PulsarAdminInvocationHandler.java
@@ -32,6 +32,7 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -57,7 +58,9 @@ public class PulsarAdminInvocationHandler implements InvocationHandler {
     public PulsarAdminInvocationHandler(PulsarAdmin admin, PulsarConfiguration configuration) {
         this.admin = admin;
         this.retryTimes = configuration.get(PULSAR_ADMIN_REQUEST_RETRIES);
-        this.waitMillis = configuration.get(PULSAR_ADMIN_REQUEST_WAIT_MILLIS);
+        this.waitMillis =
+                configuration.getDuration(
+                        PULSAR_ADMIN_REQUEST_WAIT_MILLIS, MILLISECONDS, Duration::toMillis);
         this.requestRates = configuration.get(PULSAR_ADMIN_REQUEST_RATES);
         this.handlers = new ConcurrentHashMap<>();
     }

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/schema/factories/PrimitiveSchemaFactory.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/schema/factories/PrimitiveSchemaFactory.java
@@ -21,8 +21,6 @@ package org.apache.flink.connector.pulsar.common.schema.factories;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.connector.pulsar.common.schema.PulsarSchemaFactory;
 
-import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableSet;
-
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.schema.SchemaType;
@@ -36,27 +34,6 @@ import static org.apache.flink.util.Preconditions.checkArgument;
  */
 public class PrimitiveSchemaFactory<T> implements PulsarSchemaFactory<T> {
 
-    private static final ImmutableSet<SchemaType> PRIMITIVE_SCHEMA_TYPES =
-            ImmutableSet.<SchemaType>builder()
-                    .add(SchemaType.NONE)
-                    .add(SchemaType.BOOLEAN)
-                    .add(SchemaType.INT8)
-                    .add(SchemaType.INT16)
-                    .add(SchemaType.INT32)
-                    .add(SchemaType.INT64)
-                    .add(SchemaType.FLOAT)
-                    .add(SchemaType.DOUBLE)
-                    .add(SchemaType.BYTES)
-                    .add(SchemaType.STRING)
-                    .add(SchemaType.TIMESTAMP)
-                    .add(SchemaType.TIME)
-                    .add(SchemaType.DATE)
-                    .add(SchemaType.INSTANT)
-                    .add(SchemaType.LOCAL_DATE)
-                    .add(SchemaType.LOCAL_TIME)
-                    .add(SchemaType.LOCAL_DATE_TIME)
-                    .build();
-
     private final SchemaType type;
     private final Schema<T> schema;
     private final TypeInformation<T> typeInformation;
@@ -67,7 +44,7 @@ public class PrimitiveSchemaFactory<T> implements PulsarSchemaFactory<T> {
 
     public PrimitiveSchemaFactory(
             SchemaType type, Schema<T> schema, TypeInformation<T> typeInformation) {
-        checkArgument(PRIMITIVE_SCHEMA_TYPES.contains(type));
+        checkArgument(type.isPrimitive());
 
         this.type = type;
         this.schema = schema;

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/topic/TopicNameUtils.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/topic/TopicNameUtils.java
@@ -124,8 +124,8 @@ public final class TopicNameUtils {
      * @see <a
      *     href="https://github.com/apache/pulsar/blob/b969fe5e56cc768632e52e9534a1e94b75c29be1/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java#L1481">NamespaceService#isSystemServiceNamespace</a>
      */
-    private static boolean isSystemServiceNamespace(String namespace) {
-        return namespace.equals(SYSTEM_NAMESPACE.toString())
+    public static boolean isSystemServiceNamespace(String namespace) {
+        return SYSTEM_NAMESPACE.toString().equals(namespace)
                 || SLA_NAMESPACE_PATTERN.matcher(namespace).matches()
                 || HEARTBEAT_NAMESPACE_PATTERN.matcher(namespace).matches()
                 || HEARTBEAT_NAMESPACE_PATTERN_V2.matcher(namespace).matches();

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/table/catalog/PulsarCatalog.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/table/catalog/PulsarCatalog.java
@@ -1,0 +1,522 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.table.catalog;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.connector.pulsar.common.config.PulsarConfigBuilder;
+import org.apache.flink.connector.pulsar.table.catalog.client.PulsarCatalogClient;
+import org.apache.flink.connector.pulsar.table.catalog.config.CatalogConfiguration;
+import org.apache.flink.table.catalog.AbstractCatalog;
+import org.apache.flink.table.catalog.CatalogBaseTable;
+import org.apache.flink.table.catalog.CatalogDatabase;
+import org.apache.flink.table.catalog.CatalogFunction;
+import org.apache.flink.table.catalog.CatalogPartition;
+import org.apache.flink.table.catalog.CatalogPartitionSpec;
+import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.ResolvedCatalogTable;
+import org.apache.flink.table.catalog.ResolvedCatalogView;
+import org.apache.flink.table.catalog.exceptions.CatalogException;
+import org.apache.flink.table.catalog.exceptions.DatabaseAlreadyExistException;
+import org.apache.flink.table.catalog.exceptions.DatabaseNotEmptyException;
+import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
+import org.apache.flink.table.catalog.exceptions.TableAlreadyExistException;
+import org.apache.flink.table.catalog.exceptions.TableNotExistException;
+import org.apache.flink.table.catalog.stats.CatalogColumnStatistics;
+import org.apache.flink.table.catalog.stats.CatalogTableStatistics;
+import org.apache.flink.table.expressions.Expression;
+import org.apache.flink.table.factories.Factory;
+
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.common.naming.TopicDomain;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_ADMIN_URL;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_SERVICE_URL;
+import static org.apache.flink.connector.pulsar.table.catalog.PulsarCatalogOptions.LOCAL_PULSAR_ADMIN_URL;
+import static org.apache.flink.connector.pulsar.table.catalog.PulsarCatalogOptions.LOCAL_PULSAR_SERVICE_URL;
+import static org.apache.flink.connector.pulsar.table.catalog.config.PulsarCatalogConfigUtils.CATALOG_VALIDATOR;
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.StringUtils.isNullOrWhitespaceOnly;
+
+/**
+ * Catalog implementation which uses Pulsar to store Flink created databases/tables, exposes the
+ * Pulsar's namespace as the Flink databases and exposes the Pulsar's topics as the Flink tables.
+ *
+ * <h2>Database Mapping</h2>
+ *
+ * <p>{@link PulsarCatalog} offers two kinds of databases.
+ *
+ * <ul>
+ *   <li><strong>Managed Databases</strong><br>
+ *       A managed database refers to a database created by using Flink but the its name doesn't
+ *       contain tenant information.<br>
+ *       We will created the corresponding namespace under the tenant configured by {@link
+ *       PulsarCatalogOptions#PULSAR_CATALOG_MANAGED_TENANT}.
+ *   <li><strong>Pulsar Databases</strong><br>
+ *       A Pulsar databases refers to an existing namespace that wasn't a system namespace nor under
+ *       the Flink managed tenant in Pulsar. Each namespace will be mapped to a database using the
+ *       tenant and namespace name like {@code tenant/namespace}.
+ * </ul>
+ *
+ * <h2>Table Mapping</h2>
+ *
+ * <p>A table refers to a Pulsar topic, using a 1-to-1 mapping from the Pulsar's {@link
+ * TopicDomain#persistent} topic to the Flink table. We don't support {@link
+ * TopicDomain#non_persistent} topics here.
+ *
+ * <p>Each topic will be mapped to a table under a database using the topic's tenant and namespace
+ * named like {@code tenant/namespace}. The mapped table has the same name as the local name of the
+ * original topic. For example, the topic {@code persistent://public/default/some} will be mapped to
+ * {@code some} table under the {@code public/default} database. This allows users to easily query
+ * from existing Pulsar topics without explicitly creating the table. It automatically determines
+ * the Flink format to use based on the stored Pulsar schema in the Pulsar topic.
+ *
+ * <p>This mapping has some limitations, such as users can't designate the watermark and thus can't
+ * use window aggregate functions for the topics that aren't created by catalog.
+ */
+@PublicEvolving
+@SuppressWarnings("java:S1192")
+public class PulsarCatalog extends AbstractCatalog {
+    private static final Logger LOG = LoggerFactory.getLogger(PulsarCatalog.class);
+
+    private final CatalogConfiguration configuration;
+
+    private PulsarCatalogClient client;
+
+    public PulsarCatalog(String catalogName, CatalogConfiguration configuration) {
+        super(catalogName, configuration.getDefaultDatabase());
+
+        PulsarConfigBuilder builder = new PulsarConfigBuilder(configuration);
+
+        // Set the required options for supporting the local catalog.
+        builder.setIfMissing(PULSAR_SERVICE_URL, LOCAL_PULSAR_SERVICE_URL);
+        builder.setIfMissing(PULSAR_ADMIN_URL, LOCAL_PULSAR_ADMIN_URL);
+
+        // We may create the CatalogConfiguration twice when using the PulsarCatalogFactory.
+        // But we truly add the config validation when you want to manually create the Pulsar
+        // catalog.
+        this.configuration = builder.build(CATALOG_VALIDATOR, CatalogConfiguration::new);
+    }
+
+    @Override
+    public Optional<Factory> getFactory() {
+        // We will add PulsarDynamicTableFactory support here in the upcoming PRs.
+        return Optional.empty();
+    }
+
+    @Override
+    public void open() throws CatalogException {
+        // Create the catalog client.
+        if (client == null) {
+            try {
+                this.client = new PulsarCatalogClient(getName(), configuration);
+            } catch (PulsarClientException e) {
+                String message =
+                        "Failed to create the client in catalog "
+                                + getName()
+                                + ", config is: "
+                                + configuration;
+                throw new CatalogException(message, e);
+            }
+        }
+
+        // Create the flink managed tenant.
+        try {
+            client.initializeManagedTenant();
+        } catch (PulsarAdminException e) {
+            String managedTenant = configuration.getManagedTenant();
+            String message =
+                    "Failed to initialize the Flink managed tenant: "
+                            + managedTenant
+                            + " in catalog: "
+                            + getName()
+                            + " with config: "
+                            + configuration;
+            throw new CatalogException(message, e);
+        }
+    }
+
+    @Override
+    public void close() throws CatalogException {
+        if (client != null) {
+            client.close();
+            LOG.debug("Successfully close the catalog client.");
+        }
+    }
+
+    // ------ databases ------
+
+    @Override
+    public List<String> listDatabases() throws CatalogException {
+        try {
+            return client.listDatabases();
+        } catch (PulsarAdminException e) {
+            String message = "Failed to list the databases in catalog: " + getName();
+            throw new CatalogException(message, e);
+        }
+    }
+
+    @Override
+    public CatalogDatabase getDatabase(String databaseName)
+            throws DatabaseNotExistException, CatalogException {
+        try {
+            return client.getDatabase(databaseName);
+        } catch (PulsarAdminException e) {
+            String message =
+                    "Failed to query the given database: "
+                            + databaseName
+                            + " in catalog: "
+                            + getName();
+            throw new CatalogException(message, e);
+        }
+    }
+
+    @Override
+    public boolean databaseExists(String databaseName) throws CatalogException {
+        try {
+            return client.databaseExists(databaseName);
+        } catch (PulsarAdminException e) {
+            String message =
+                    "Failed to check if database: "
+                            + databaseName
+                            + " exists in catalog: "
+                            + getName();
+            throw new CatalogException(message, e);
+        }
+    }
+
+    @Override
+    public void createDatabase(String name, CatalogDatabase database, boolean ignoreIfExists)
+            throws DatabaseAlreadyExistException, CatalogException {
+        try {
+            client.createDatabase(name, database, ignoreIfExists);
+        } catch (PulsarAdminException e) {
+            String message = "Failed to create database: " + name + " in catalog: " + getName();
+            throw new CatalogException(message, e);
+        }
+    }
+
+    @Override
+    public void dropDatabase(String name, boolean ignoreIfNotExists, boolean cascade)
+            throws DatabaseNotExistException, DatabaseNotEmptyException, CatalogException {
+        try {
+            client.dropDatabase(name, ignoreIfNotExists, cascade);
+        } catch (PulsarAdminException e) {
+            String message = "Failed to drop database: " + name + " in catalog: " + getName();
+            throw new CatalogException(message, e);
+        }
+    }
+
+    @Override
+    public void alterDatabase(String name, CatalogDatabase newDatabase, boolean ignoreIfNotExists)
+            throws DatabaseNotExistException, CatalogException {
+        try {
+            client.alterDatabase(name, newDatabase, ignoreIfNotExists);
+        } catch (PulsarAdminException e) {
+            String message = "Failed to alter database: " + name + " in catalog: " + getName();
+            throw new CatalogException(message, e);
+        }
+    }
+
+    // ------ tables and views ------
+
+    @Override
+    public List<String> listTables(String name) throws DatabaseNotExistException, CatalogException {
+        try {
+            return client.listTables(name);
+        } catch (PulsarAdminException e) {
+            String message =
+                    "Failed to list tables of database: " + name + " in catalog: " + getName();
+            throw new CatalogException(message, e);
+        }
+    }
+
+    @Override
+    public List<String> listViews(String name) throws CatalogException {
+        throw new UnsupportedOperationException("Pulsar catalog don't support view");
+    }
+
+    @Override
+    public CatalogBaseTable getTable(ObjectPath tablePath)
+            throws TableNotExistException, CatalogException {
+        return null;
+    }
+
+    @Override
+    public boolean tableExists(ObjectPath tablePath) throws CatalogException {
+        checkNotNull(tablePath, "tablePath cannot be null");
+        try {
+            return client.tableExists(tablePath);
+        } catch (PulsarAdminException e) {
+            String message =
+                    "Failed to check if table: " + tablePath + " exists in catalog: " + getName();
+            throw new CatalogException(message, e);
+        }
+    }
+
+    @Override
+    public void dropTable(ObjectPath tablePath, boolean ignoreIfNotExists)
+            throws TableNotExistException, CatalogException {
+        checkNotNull(tablePath, "tablePath cannot be null");
+
+        try {
+            client.dropTable(tablePath, ignoreIfNotExists);
+        } catch (PulsarAdminException e) {
+            String message = "Failed to delete table: " + tablePath + " in catalog: " + getName();
+            throw new CatalogException(message, e);
+        }
+    }
+
+    @Override
+    public void renameTable(ObjectPath tablePath, String newTableName, boolean ignoreIfNotExists)
+            throws TableNotExistException, TableAlreadyExistException, CatalogException {
+        checkNotNull(tablePath, "tablePath cannot be null");
+        checkArgument(
+                !isNullOrWhitespaceOnly(newTableName), "newTableName cannot be null or empty");
+
+        try {
+            client.renameTable(tablePath, newTableName, ignoreIfNotExists);
+        } catch (PulsarAdminException e) {
+            String message =
+                    "Failed to rename table: "
+                            + tablePath
+                            + " to new name: "
+                            + newTableName
+                            + " in catalog: "
+                            + getName();
+            throw new CatalogException(message, e);
+        }
+    }
+
+    @Override
+    public void createTable(ObjectPath tablePath, CatalogBaseTable table, boolean ignoreIfExists)
+            throws TableAlreadyExistException, DatabaseNotExistException, CatalogException {
+        checkNotNull(tablePath, "tablePath cannot be null");
+        checkNotNull(table, "table cannot be null");
+
+        if (table instanceof ResolvedCatalogTable) {
+            try {
+                client.createTable(tablePath, (ResolvedCatalogTable) table, ignoreIfExists);
+            } catch (PulsarAdminException e) {
+                String message =
+                        "Failed to create table: " + tablePath + " in catalog: " + getName();
+                throw new CatalogException(message, e);
+            }
+        } else if (table instanceof ResolvedCatalogView) {
+            throw new UnsupportedOperationException("Pulsar catalog don't support view");
+        } else {
+            throw new UnsupportedOperationException(
+                    "We don't support such kind of table: " + table.getClass());
+        }
+    }
+
+    @Override
+    public void alterTable(
+            ObjectPath tablePath, CatalogBaseTable newTable, boolean ignoreIfNotExists)
+            throws TableNotExistException, CatalogException {
+        checkNotNull(tablePath, "tablePath cannot be null");
+        checkNotNull(newTable, "newCatalogTable cannot be null");
+
+        if (newTable instanceof ResolvedCatalogTable) {
+            try {
+                client.alterTable(tablePath, (ResolvedCatalogTable) newTable, ignoreIfNotExists);
+            } catch (PulsarAdminException e) {
+                String message =
+                        "Failed to alter table: " + tablePath + " in catalog: " + getName();
+                throw new CatalogException(message, e);
+            }
+        } else if (newTable instanceof ResolvedCatalogView) {
+            throw new UnsupportedOperationException("Pulsar catalog don't support view");
+        } else {
+            throw new UnsupportedOperationException(
+                    "We don't support such kind of table: " + newTable.getClass());
+        }
+    }
+
+    @Override
+    public boolean supportsManagedTable() {
+        return true;
+    }
+
+    // ------------------------------------------------------------------------
+    // Unsupported catalog operations for Pulsar
+    // ------------------------------------------------------------------------
+
+    // ------ partitions ------
+
+    @Override
+    public List<CatalogPartitionSpec> listPartitions(ObjectPath tablePath) throws CatalogException {
+        throw new UnsupportedOperationException("Pulsar catalog don't support partition for now");
+    }
+
+    @Override
+    public List<CatalogPartitionSpec> listPartitions(
+            ObjectPath tablePath, CatalogPartitionSpec partitionSpec) throws CatalogException {
+        throw new UnsupportedOperationException("Pulsar catalog don't support partition for now");
+    }
+
+    @Override
+    public List<CatalogPartitionSpec> listPartitionsByFilter(
+            ObjectPath tablePath, List<Expression> filters) throws CatalogException {
+        throw new UnsupportedOperationException("Pulsar catalog don't support partition for now");
+    }
+
+    @Override
+    public CatalogPartition getPartition(ObjectPath tablePath, CatalogPartitionSpec partitionSpec)
+            throws CatalogException {
+        throw new UnsupportedOperationException("Pulsar catalog don't support partition for now");
+    }
+
+    @Override
+    public boolean partitionExists(ObjectPath tablePath, CatalogPartitionSpec partitionSpec)
+            throws CatalogException {
+        throw new UnsupportedOperationException("Pulsar catalog don't support partition for now");
+    }
+
+    @Override
+    public void createPartition(
+            ObjectPath tablePath,
+            CatalogPartitionSpec partitionSpec,
+            CatalogPartition partition,
+            boolean ignoreIfExists)
+            throws CatalogException {
+        throw new UnsupportedOperationException("Pulsar catalog don't support partition for now");
+    }
+
+    @Override
+    public void dropPartition(
+            ObjectPath tablePath, CatalogPartitionSpec partitionSpec, boolean ignoreIfNotExists)
+            throws CatalogException {
+        throw new UnsupportedOperationException("Pulsar catalog don't support partition for now");
+    }
+
+    @Override
+    public void alterPartition(
+            ObjectPath tablePath,
+            CatalogPartitionSpec partitionSpec,
+            CatalogPartition newPartition,
+            boolean ignoreIfNotExists)
+            throws CatalogException {
+        throw new UnsupportedOperationException("Pulsar catalog don't support partition for now");
+    }
+
+    // ------ functions ------
+
+    @Override
+    public List<String> listFunctions(String dbName) throws CatalogException {
+        throw new UnsupportedOperationException("Pulsar catalog don't support function for now");
+    }
+
+    @Override
+    public CatalogFunction getFunction(ObjectPath functionPath) throws CatalogException {
+        throw new UnsupportedOperationException("Pulsar catalog don't support function for now");
+    }
+
+    @Override
+    public boolean functionExists(ObjectPath functionPath) throws CatalogException {
+        throw new UnsupportedOperationException("Pulsar catalog don't support function for now");
+    }
+
+    @Override
+    public void createFunction(
+            ObjectPath functionPath, CatalogFunction function, boolean ignoreIfExists)
+            throws CatalogException {
+        throw new UnsupportedOperationException("Pulsar catalog don't support function for now");
+    }
+
+    @Override
+    public void alterFunction(
+            ObjectPath functionPath, CatalogFunction newFunction, boolean ignoreIfNotExists)
+            throws CatalogException {
+        throw new UnsupportedOperationException("Pulsar catalog don't support function for now");
+    }
+
+    @Override
+    public void dropFunction(ObjectPath functionPath, boolean ignoreIfNotExists)
+            throws CatalogException {
+        throw new UnsupportedOperationException("Pulsar catalog don't support function for now");
+    }
+
+    // ------ statistics ------
+
+    @Override
+    public CatalogTableStatistics getTableStatistics(ObjectPath tablePath) throws CatalogException {
+        throw new UnsupportedOperationException("Pulsar catalog don't support statistic for now");
+    }
+
+    @Override
+    public CatalogColumnStatistics getTableColumnStatistics(ObjectPath tablePath)
+            throws CatalogException {
+        throw new UnsupportedOperationException("Pulsar catalog don't support statistic for now");
+    }
+
+    @Override
+    public CatalogTableStatistics getPartitionStatistics(
+            ObjectPath tablePath, CatalogPartitionSpec partitionSpec) throws CatalogException {
+        throw new UnsupportedOperationException("Pulsar catalog don't support statistic for now");
+    }
+
+    @Override
+    public CatalogColumnStatistics getPartitionColumnStatistics(
+            ObjectPath tablePath, CatalogPartitionSpec partitionSpec) throws CatalogException {
+        throw new UnsupportedOperationException("Pulsar catalog don't support statistic for now");
+    }
+
+    @Override
+    public void alterTableStatistics(
+            ObjectPath tablePath, CatalogTableStatistics tableStatistics, boolean ignoreIfNotExists)
+            throws CatalogException {
+        throw new UnsupportedOperationException("Pulsar catalog don't support statistic for now");
+    }
+
+    @Override
+    public void alterTableColumnStatistics(
+            ObjectPath tablePath,
+            CatalogColumnStatistics columnStatistics,
+            boolean ignoreIfNotExists)
+            throws CatalogException {
+        throw new UnsupportedOperationException("Pulsar catalog don't support statistic for now");
+    }
+
+    @Override
+    public void alterPartitionStatistics(
+            ObjectPath tablePath,
+            CatalogPartitionSpec partitionSpec,
+            CatalogTableStatistics partitionStatistics,
+            boolean ignoreIfNotExists)
+            throws CatalogException {
+        throw new UnsupportedOperationException("Pulsar catalog don't support statistic for now");
+    }
+
+    @Override
+    public void alterPartitionColumnStatistics(
+            ObjectPath tablePath,
+            CatalogPartitionSpec partitionSpec,
+            CatalogColumnStatistics columnStatistics,
+            boolean ignoreIfNotExists)
+            throws CatalogException {
+        throw new UnsupportedOperationException("Pulsar catalog don't support statistic for now");
+    }
+}

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/table/catalog/PulsarCatalogOptions.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/table/catalog/PulsarCatalogOptions.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.table.catalog;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.docs.ConfigGroup;
+import org.apache.flink.annotation.docs.ConfigGroups;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.configuration.description.Description;
+
+import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableSet;
+
+import org.apache.pulsar.common.schema.SchemaType;
+
+import java.util.Set;
+
+import static org.apache.flink.configuration.description.TextElement.code;
+import static org.apache.flink.connector.pulsar.table.catalog.PulsarCatalogOptions.CATALOG_CONFIG_PREFIX;
+import static org.apache.flink.table.catalog.CommonCatalogOptions.DEFAULT_DATABASE_KEY;
+import static org.apache.pulsar.common.schema.SchemaType.AVRO;
+import static org.apache.pulsar.common.schema.SchemaType.JSON;
+
+/**
+ * Config options that is used to configure a {@link PulsarCatalog}. These config options are
+ * specific to catalog only. Other runtime configurations can be found in {@link
+ * org.apache.flink.connector.pulsar.common.config.PulsarOptions}.
+ */
+@PublicEvolving
+@ConfigGroups(groups = {@ConfigGroup(name = "PulsarCatalog", keyPrefix = CATALOG_CONFIG_PREFIX)})
+public final class PulsarCatalogOptions {
+
+    // Pulsar catalog name.
+    public static final String IDENTIFIER = "pulsar";
+    public static final String LOCAL_IDENTIFIER = "local-pulsar";
+    // Pulsar catalog config prefix.
+    public static final String CATALOG_CONFIG_PREFIX = "pulsar.catalog.";
+    // Default Pulsar connection endpoints.
+    public static final String LOCAL_PULSAR_SERVICE_URL = "pulsar://127.0.0.1:6650";
+    public static final String LOCAL_PULSAR_ADMIN_URL = "http://127.0.0.1:8080";
+    // Managed topic for naming mapping.
+    public static final String NAMING_MAPPING_TOPIC = "__flink_table_name_mapping";
+    // Allowed schema types for tables.
+    public static final Set<SchemaType> ALLOWED_SCHEMA_TYPES = ImmutableSet.of(JSON, AVRO);
+
+    private PulsarCatalogOptions() {
+        // This is a constant class
+    }
+
+    public static final ConfigOption<String> PULSAR_CATALOG_DEFAULT_DATABASE =
+            ConfigOptions.key(CATALOG_CONFIG_PREFIX + "defaultDatabase")
+                    .stringType()
+                    .defaultValue("public/default")
+                    .withFallbackKeys(DEFAULT_DATABASE_KEY)
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "This is the default database name to use when you enable the Pulsar Catalog.")
+                                    .text(
+                                            " We will use %s by default which will query all the tables under the % tenant and %s namespace.",
+                                            code("public/default"), code("public"), code("default"))
+                                    .text(
+                                            " You can also config this option by using common table config name %s",
+                                            code(DEFAULT_DATABASE_KEY))
+                                    .build());
+
+    public static final ConfigOption<String> PULSAR_CATALOG_MANAGED_TENANT =
+            ConfigOptions.key(CATALOG_CONFIG_PREFIX + "managedTenant")
+                    .stringType()
+                    .defaultValue("__flink_catalog_managed")
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "If you create a database without the tenant information, we will create it under this tenant.")
+                                    .text(
+                                            " This tenant will be auto created when you enable the PulsarCatalog. Remember you admin token must has the authority to create it.")
+                                    .text(
+                                            " Or you can manually create a tenant in Pulsar for serving as the catalog managed tenant, and provide it here.")
+                                    .build());
+
+    public static final ConfigOption<String> PULSAR_CATALOG_HIDDEN_TENANT_PATTERN =
+            ConfigOptions.key(CATALOG_CONFIG_PREFIX + "hiddenTenantPattern")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "Different user may share the same Pulsar cluster with different managed tenants.")
+                                    .text(
+                                            " Use this regular expression to hide the tenants that you don't want to show to the users.")
+                                    .build());
+
+    public static final ConfigOption<String> PULSAR_CATALOG_VISIBLE_TENANT_PATTERN =
+            ConfigOptions.key(CATALOG_CONFIG_PREFIX + "visibleTenantPattern")
+                    .stringType()
+                    .defaultValue(".*")
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "Use this regular expression to choose the tenants you want to use in catalog.")
+                                    .text(
+                                            " We will show all the tenants except the Pulsar's internal tenants by default.")
+                                    .build());
+
+    public static final ConfigOption<SchemaType> PULSAR_CATALOG_DEFAULT_SCHEMA_TYPE =
+            ConfigOptions.key(CATALOG_CONFIG_PREFIX + "defaultSchemaType")
+                    .enumType(SchemaType.class)
+                    .defaultValue(JSON)
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "We will create the schema for the tables created in catalog.")
+                                    .text(" Use this option to defined the default schema type.")
+                                    .text(
+                                            " We only support %s and %s now.",
+                                            code(JSON.name()), code(AVRO.name()))
+                                    .build());
+
+    public static final ConfigOption<Integer> PULSAR_CATALOG_DEFAULT_PARTITION_SIZE =
+            ConfigOptions.key(CATALOG_CONFIG_PREFIX + "defaultPartitionSize")
+                    .intType()
+                    .defaultValue(1)
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "The number of the partition size for the tables created by catalog.")
+                                    .text(" It should be a positive number.")
+                                    .build());
+}

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/table/catalog/client/PulsarCatalogClient.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/table/catalog/client/PulsarCatalogClient.java
@@ -1,0 +1,406 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.table.catalog.client;
+
+import org.apache.flink.connector.pulsar.table.catalog.config.CatalogConfiguration;
+import org.apache.flink.connector.pulsar.table.catalog.converter.CatalogDatabaseConverter;
+import org.apache.flink.connector.pulsar.table.catalog.converter.CatalogTableConverter;
+import org.apache.flink.table.catalog.CatalogDatabase;
+import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.ResolvedCatalogTable;
+import org.apache.flink.table.catalog.exceptions.CatalogException;
+import org.apache.flink.table.catalog.exceptions.DatabaseAlreadyExistException;
+import org.apache.flink.table.catalog.exceptions.DatabaseNotEmptyException;
+import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
+import org.apache.flink.table.catalog.exceptions.TableAlreadyExistException;
+import org.apache.flink.table.catalog.exceptions.TableNotExistException;
+
+import org.apache.pulsar.client.admin.ListNamespaceTopicsOptions;
+import org.apache.pulsar.client.admin.Mode;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.admin.PulsarAdminException.ConflictException;
+import org.apache.pulsar.client.admin.PulsarAdminException.NotFoundException;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.common.naming.NamespaceName;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.policies.data.TenantInfo;
+import org.apache.pulsar.common.schema.SchemaInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.stream.Collectors.toMap;
+import static org.apache.flink.connector.pulsar.common.config.PulsarClientFactory.createAdmin;
+import static org.apache.flink.connector.pulsar.source.enumerator.topic.TopicNameUtils.isSystemServiceNamespace;
+import static org.apache.pulsar.common.policies.data.SchemaCompatibilityStrategy.ALWAYS_COMPATIBLE;
+
+/**
+ * A catalog client for connecting to Pulsar with admin API. This client also provides all the
+ * operations for the Pulsar catalog.
+ */
+public class PulsarCatalogClient implements Closeable {
+    private static final Logger LOG = LoggerFactory.getLogger(PulsarCatalogClient.class);
+
+    private final String catalogName;
+    private final PulsarAdmin admin;
+    private final TableNameMapper nameMapper;
+    private final String managedTenant;
+    private final CatalogConfiguration configuration;
+
+    // The converters for simplifying the transform logics.
+    private final CatalogDatabaseConverter databaseConverter;
+    private final CatalogTableConverter tableConverter;
+
+    public PulsarCatalogClient(String catalogName, CatalogConfiguration configuration)
+            throws PulsarClientException {
+        this.catalogName = catalogName;
+        this.admin = createAdmin(configuration);
+        this.nameMapper = new TableNameMapper(admin);
+        this.managedTenant = configuration.getManagedTenant();
+        this.configuration = configuration;
+
+        this.databaseConverter = new CatalogDatabaseConverter();
+        this.tableConverter = new CatalogTableConverter(configuration);
+    }
+
+    public void initializeManagedTenant() throws PulsarAdminException {
+        try {
+            TenantInfo info = admin.tenants().getTenantInfo(managedTenant);
+            LOG.debug("The tenant {} has been created with info {}", managedTenant, info);
+        } catch (NotFoundException e) {
+            // Create the managed tenant.
+            LOG.debug("Don't have the managed tenant {}, try to create it.", managedTenant);
+            List<String> clusters = admin.clusters().getClusters();
+            TenantInfo tenantInfo =
+                    TenantInfo.builder().allowedClusters(new HashSet<>(clusters)).build();
+            admin.tenants().createTenant(managedTenant, tenantInfo);
+        }
+    }
+
+    public List<String> listDatabases() throws PulsarAdminException {
+        List<String> result = new ArrayList<>();
+
+        // List all the Pulsar databases.
+        List<String> tenants = admin.tenants().getTenants();
+        for (String tenant : tenants) {
+            if (configuration.isManagedTenant(tenant) || configuration.isInternalTenant(tenant)) {
+                continue;
+            }
+            List<String> namespaces = admin.namespaces().getNamespaces(tenant);
+            for (String namespace : namespaces) {
+                if (!isSystemServiceNamespace(namespace)) {
+                    result.add(namespace);
+                }
+            }
+        }
+
+        // List all the Flink managed databases.
+        List<String> namespaces = admin.namespaces().getNamespaces(managedTenant);
+        for (String namespace : namespaces) {
+            // Use this parsing method instead of directly split it.
+            result.add(NamespaceName.get(namespace).getLocalName());
+        }
+
+        if (result.isEmpty()) {
+            LOG.warn(
+                    "No databases are allowed to show to the end user. Check you config: {}",
+                    configuration);
+        }
+
+        return result;
+    }
+
+    public CatalogDatabase getDatabase(String name)
+            throws DatabaseNotExistException, PulsarAdminException {
+        if (configuration.isInternalDatabase(name)) {
+            IllegalArgumentException e =
+                    new IllegalArgumentException("You can't access the internal database");
+            throw new DatabaseNotExistException(catalogName, name, e);
+        }
+
+        try {
+            String databaseName = configuration.databaseName(name);
+            Map<String, String> properties = admin.namespaces().getProperties(databaseName);
+
+            return databaseConverter.reverse().convert(properties);
+        } catch (NotFoundException e) {
+            throw new DatabaseNotExistException(catalogName, name, e);
+        }
+    }
+
+    public boolean databaseExists(String name) throws PulsarAdminException {
+        if (configuration.isInternalDatabase(name)) {
+            LOG.debug("This is an internal database {}, return false for existing checking.", name);
+            return false;
+        }
+
+        try {
+            String databaseName = configuration.databaseName(name);
+            admin.namespaces().getProperties(databaseName);
+
+            // No exception has been thrown means this is an existed database.
+            return true;
+        } catch (NotFoundException e) {
+            return false;
+        }
+    }
+
+    public void createDatabase(String name, CatalogDatabase database, boolean ignoreIfExists)
+            throws PulsarAdminException, DatabaseAlreadyExistException {
+        if (configuration.isInternalDatabase(name)) {
+            throw new CatalogException(name + " is a preserved Pulsar internal database");
+        }
+
+        String databaseName = configuration.databaseName(name);
+
+        try {
+            admin.namespaces().createNamespace(databaseName);
+        } catch (ConflictException e) {
+            // The database is already existed in Pulsar.
+            if (ignoreIfExists) {
+                // Skip the properties setting for an existed database.
+                return;
+            } else {
+                throw new DatabaseAlreadyExistException(catalogName, name, e);
+            }
+        }
+
+        Map<String, String> properties = databaseConverter.convert(database);
+        admin.namespaces().setProperties(databaseName, properties);
+    }
+
+    public void dropDatabase(String name, boolean ignoreIfNotExists, boolean cascade)
+            throws PulsarAdminException, DatabaseNotExistException, DatabaseNotEmptyException {
+        if (configuration.isInternalDatabase(name)) {
+            throw new CatalogException(
+                    name + " is an internal database, you don't have write access");
+        }
+
+        String databaseName = configuration.databaseName(name);
+
+        // List all the topics include the non-persistent topics for checking.
+        List<String> topics;
+        try {
+            ListNamespaceTopicsOptions options =
+                    ListNamespaceTopicsOptions.builder()
+                            .includeSystemTopic(false)
+                            .mode(Mode.ALL)
+                            .build();
+            topics = admin.namespaces().getTopics(databaseName, options);
+        } catch (NotFoundException e) {
+            if (ignoreIfNotExists) {
+                return;
+            } else {
+                throw new DatabaseNotExistException(catalogName, name, e);
+            }
+        }
+
+        // Check if this is an empty database.
+        if (!topics.isEmpty() && !cascade) {
+            throw new DatabaseNotEmptyException(catalogName, name);
+        }
+
+        // Delete all the tables under this database.
+        for (String topic : topics) {
+            LOG.warn("Delete table {} due to we want to remove the database {}", topic, name);
+            admin.topics().delete(topic, true);
+        }
+
+        // Delete the database itself with the force flag to remove all the tables.
+        admin.namespaces().deleteNamespace(databaseName, true);
+    }
+
+    public void alterDatabase(String name, CatalogDatabase newDatabase, boolean ignoreIfNotExists)
+            throws PulsarAdminException, DatabaseNotExistException {
+        if (configuration.isInternalDatabase(name)) {
+            throw new CatalogException(
+                    name + " is an internal database, you don't have write access");
+        }
+
+        String databaseName = configuration.databaseName(name);
+
+        try {
+            admin.namespaces().getProperties(databaseName);
+        } catch (NotFoundException e) {
+            if (ignoreIfNotExists) {
+                return;
+            } else {
+                throw new DatabaseNotExistException(catalogName, name, e);
+            }
+        }
+
+        // Update the database properties.
+        Map<String, String> properties = databaseConverter.convert(newDatabase);
+        admin.namespaces().setProperties(databaseName, properties);
+    }
+
+    public List<String> listTables(String name)
+            throws PulsarAdminException, DatabaseNotExistException {
+        if (configuration.isInternalDatabase(name)) {
+            throw new CatalogException(name + " is an internal database, you can't get its tables");
+        }
+
+        String databaseName = configuration.databaseName(name);
+
+        // We only support the persistent topics.
+        ListNamespaceTopicsOptions options =
+                ListNamespaceTopicsOptions.builder()
+                        .includeSystemTopic(false)
+                        .mode(Mode.PERSISTENT)
+                        .build();
+        try {
+            List<String> topics = admin.namespaces().getTopics(databaseName, options);
+            Map<String, String> nameMapping =
+                    nameMapper.listMapping(databaseName).entrySet().stream()
+                            .collect(toMap(Map.Entry::getValue, Map.Entry::getKey));
+
+            // Convert the topic name into table name.
+            List<String> tables = new ArrayList<>(topics.size());
+            for (String topic : topics) {
+                String table = TopicName.get(topic).getLocalName();
+                if (!configuration.isInternalTable(databaseName, table)) {
+                    tables.add(nameMapping.getOrDefault(table, table));
+                }
+            }
+
+            return tables;
+        } catch (NotFoundException e) {
+            throw new DatabaseNotExistException(catalogName, name, e);
+        }
+    }
+
+    public boolean tableExists(ObjectPath tablePath) throws PulsarAdminException {
+        String databaseName = configuration.databaseName(tablePath.getDatabaseName());
+        String tableName = nameMapper.getMapping(databaseName, tablePath.getObjectName());
+        try {
+            String table = TopicName.get(tableName).getLocalName();
+            if (configuration.isInternalTable(databaseName, table)) {
+                return false;
+            }
+
+            admin.topics().getPartitionedTopicMetadata(tableName);
+            return true;
+        } catch (NotFoundException e) {
+            return false;
+        }
+    }
+
+    public void dropTable(ObjectPath tablePath, boolean ignoreIfNotExists)
+            throws PulsarAdminException, TableNotExistException {
+        if (!tableExists(tablePath)) {
+            if (ignoreIfNotExists) {
+                return;
+            } else {
+                throw new TableNotExistException(catalogName, tablePath);
+            }
+        }
+
+        String databaseName = configuration.databaseName(tablePath.getDatabaseName());
+        String tableName = nameMapper.dropMapping(databaseName, tablePath.getObjectName());
+        String table = TopicName.get(tableName).getLocalName();
+        if (configuration.isInternalTable(databaseName, table)) {
+            throw new CatalogException(
+                    "This is a internal table " + tablePath.getObjectName() + " in Pulsar catalog");
+        }
+
+        admin.topics().delete(tableName, true);
+        admin.schemas().deleteSchema(tableName);
+    }
+
+    public void renameTable(ObjectPath tablePath, String newTableName, boolean ignoreIfNotExists)
+            throws PulsarAdminException, TableNotExistException, TableAlreadyExistException {
+        if (!tableExists(tablePath)) {
+            if (!ignoreIfNotExists) {
+                throw new TableNotExistException(catalogName, tablePath);
+            } else {
+                return;
+            }
+        }
+
+        ObjectPath newPath = new ObjectPath(tablePath.getDatabaseName(), newTableName);
+        if (tableExists(newPath)) {
+            throw new TableAlreadyExistException(catalogName, newPath);
+        }
+
+        String databaseName = configuration.databaseName(newPath.getDatabaseName());
+        nameMapper.addMapping(databaseName, tablePath.getObjectName(), newTableName);
+    }
+
+    public void createTable(
+            ObjectPath tablePath, ResolvedCatalogTable table, boolean ignoreIfExists)
+            throws PulsarAdminException, DatabaseNotExistException, TableAlreadyExistException {
+        String databaseName = configuration.databaseName(tablePath.getDatabaseName());
+        if (!databaseExists(databaseName)) {
+            throw new DatabaseNotExistException(catalogName, tablePath.getDatabaseName());
+        }
+
+        if (tableExists(tablePath)) {
+            if (ignoreIfExists) {
+                return;
+            } else {
+                throw new TableAlreadyExistException(catalogName, tablePath);
+            }
+        }
+
+        String tableName = nameMapper.getMapping(databaseName, tablePath.getObjectName());
+
+        // Create the related table.
+        int partitions = configuration.getDefaultPartitionSize();
+        admin.topics().createPartitionedTopic(tableName, partitions);
+
+        // Upload the table schema and bypass schema check.
+        SchemaInfo info = tableConverter.convert(table);
+        admin.schemas().createSchema(tableName, info);
+        admin.topicPolicies().setSchemaCompatibilityStrategy(tableName, ALWAYS_COMPATIBLE);
+    }
+
+    public void alterTable(
+            ObjectPath tablePath, ResolvedCatalogTable table, boolean ignoreIfNotExists)
+            throws PulsarAdminException, TableNotExistException {
+        if (!tableExists(tablePath)) {
+            if (ignoreIfNotExists) {
+                return;
+            } else {
+                throw new TableNotExistException(catalogName, tablePath);
+            }
+        }
+
+        String databaseName = configuration.databaseName(tablePath.getDatabaseName());
+        String tableName = nameMapper.getMapping(databaseName, tablePath.getObjectName());
+        SchemaInfo info = admin.schemas().getSchemaInfo(tableName);
+        if (!tableConverter.isFlinkTable(info)) {
+            throw new CatalogException(
+                    "This table " + tablePath + " is not created by Flink, you can't modify it.");
+        }
+
+        SchemaInfo newInfo = tableConverter.convert(table);
+        admin.schemas().createSchema(tableName, newInfo);
+    }
+
+    @Override
+    public void close() {
+        admin.close();
+    }
+}

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/table/catalog/client/TableNameMapper.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/table/catalog/client/TableNameMapper.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.table.catalog.client;
+
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.admin.PulsarAdminException.NotFoundException;
+import org.apache.pulsar.common.naming.NamespaceName;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.schema.SchemaInfo;
+import org.apache.pulsar.common.schema.SchemaType;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.flink.connector.pulsar.table.catalog.PulsarCatalogOptions.NAMING_MAPPING_TOPIC;
+import static org.apache.pulsar.common.naming.TopicDomain.persistent;
+
+/**
+ * This is a table name mapping for the renamed tables. The topic in Pulsar doesn't support
+ * renaming. So we create an internal topic under any namespaces for recording its table name
+ * mapping.
+ */
+class TableNameMapper {
+
+    private final PulsarAdmin admin;
+
+    public TableNameMapper(PulsarAdmin admin) {
+        this.admin = admin;
+    }
+
+    /** Rename the given table name with a new table. */
+    public void addMapping(String database, String table, String newTable)
+            throws PulsarAdminException {
+        String mappingTopic = internalMappingTopic(database);
+        SchemaInfo info = admin.schemas().getSchemaInfo(mappingTopic);
+
+        Map<String, String> properties = new HashMap<>(info.getProperties());
+        String originalTable = properties.remove(table);
+        if (originalTable != null) {
+            properties.put(newTable, originalTable);
+        } else {
+            properties.put(newTable, table);
+        }
+
+        SchemaInfo newInfo =
+                SchemaInfo.builder()
+                        .name(info.getName())
+                        .type(info.getType())
+                        .schema(info.getSchema())
+                        .properties(properties)
+                        .timestamp(System.currentTimeMillis())
+                        .build();
+        admin.schemas().createSchema(mappingTopic, newInfo);
+    }
+
+    /** Drop the name mapping and return the original topic name. */
+    public String dropMapping(String database, String table) throws PulsarAdminException {
+        Map<String, String> mappingTopic = listMapping(database);
+        String original = mappingTopic.remove(table);
+
+        if (original == null) {
+            original = table;
+        } else {
+            String topic = topicName(database, NAMING_MAPPING_TOPIC);
+            SchemaInfo info = schemaInfo(mappingTopic);
+            admin.schemas().createSchema(topic, info);
+        }
+
+        return topicName(database, original);
+    }
+
+    /** Get the real table name (mayn't exist) with the full path from the given database. */
+    public String getMapping(String database, String table) throws PulsarAdminException {
+        Map<String, String> nameMapping = listMapping(database);
+        String mapping = nameMapping.getOrDefault(table, table);
+
+        return topicName(database, mapping);
+    }
+
+    /**
+     * Find all the name mapping for the given database. The key will be the table name, the value
+     * will be the topic name.
+     */
+    public Map<String, String> listMapping(String database) throws PulsarAdminException {
+        String mappingTopic = internalMappingTopic(database);
+        SchemaInfo info = admin.schemas().getSchemaInfo(mappingTopic);
+
+        return new HashMap<>(info.getProperties());
+    }
+
+    /** Create of find the internal mapping topic from the given database. */
+    private String internalMappingTopic(String database) throws PulsarAdminException {
+        String topic = topicName(database, NAMING_MAPPING_TOPIC);
+
+        try {
+            admin.topics().getPartitionedTopicMetadata(topic);
+        } catch (NotFoundException e) {
+            // Try to create the mapping tables.
+            admin.topics().createNonPartitionedTopic(topic);
+            // Create the initial schema info for storing the metadata.
+            SchemaInfo info = schemaInfo(Collections.emptyMap());
+            admin.schemas().createSchema(topic, info);
+        }
+
+        return topic;
+    }
+
+    private SchemaInfo schemaInfo(Map<String, String> mapping) {
+        return SchemaInfo.builder()
+                .name("FlinkTableMapping")
+                .type(SchemaType.BYTES)
+                .schema(new byte[0])
+                .properties(mapping)
+                .timestamp(System.currentTimeMillis())
+                .build();
+    }
+
+    private String topicName(String database, String table) {
+        NamespaceName namespace = NamespaceName.get(database);
+        TopicName topicName = TopicName.get(persistent.value(), namespace, table);
+
+        return topicName.getPartitionedTopicName();
+    }
+}

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/table/catalog/config/CatalogConfiguration.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/table/catalog/config/CatalogConfiguration.java
@@ -1,0 +1,217 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.table.catalog.config;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.pulsar.common.config.PulsarConfiguration;
+import org.apache.flink.connector.pulsar.common.config.PulsarOptions;
+import org.apache.flink.connector.pulsar.table.catalog.PulsarCatalog;
+import org.apache.flink.connector.pulsar.table.catalog.PulsarCatalogOptions;
+
+import org.apache.pulsar.common.naming.NamespaceName;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.schema.SchemaType;
+
+import javax.annotation.Nullable;
+
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+import static org.apache.flink.connector.pulsar.source.enumerator.topic.TopicNameUtils.isSystemServiceNamespace;
+import static org.apache.flink.connector.pulsar.table.catalog.PulsarCatalogOptions.ALLOWED_SCHEMA_TYPES;
+import static org.apache.flink.connector.pulsar.table.catalog.PulsarCatalogOptions.NAMING_MAPPING_TOPIC;
+import static org.apache.flink.connector.pulsar.table.catalog.PulsarCatalogOptions.PULSAR_CATALOG_DEFAULT_DATABASE;
+import static org.apache.flink.connector.pulsar.table.catalog.PulsarCatalogOptions.PULSAR_CATALOG_DEFAULT_PARTITION_SIZE;
+import static org.apache.flink.connector.pulsar.table.catalog.PulsarCatalogOptions.PULSAR_CATALOG_DEFAULT_SCHEMA_TYPE;
+import static org.apache.flink.connector.pulsar.table.catalog.PulsarCatalogOptions.PULSAR_CATALOG_HIDDEN_TENANT_PATTERN;
+import static org.apache.flink.connector.pulsar.table.catalog.PulsarCatalogOptions.PULSAR_CATALOG_MANAGED_TENANT;
+import static org.apache.flink.connector.pulsar.table.catalog.PulsarCatalogOptions.PULSAR_CATALOG_VISIBLE_TENANT_PATTERN;
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.pulsar.common.naming.SystemTopicNames.isSystemTopic;
+import static org.apache.pulsar.common.naming.TopicDomain.persistent;
+
+/**
+ * The configured class for the Pulsar catalog. It's required when user wants to manually create a
+ * {@link PulsarCatalog}. You can use the following code to create this.
+ *
+ * <p>All the allowed config options for this class are defined in {@link PulsarCatalogOptions} and
+ * {@link PulsarOptions}.
+ *
+ * <pre><code>
+ * Configuration config = new Configuration();
+ * config.set(PulsarOptions.PULSAR_SERVICE_URL, "pulsar://example.com:6650");
+ * config.set(PulsarOptions.PULSAR_ADMIN_URL, "http://example.com:8080");
+ *
+ * CatalogConfiguration configuration = new CatalogConfiguration(config);
+ * </code></pre>
+ */
+@PublicEvolving
+public final class CatalogConfiguration extends PulsarConfiguration {
+    private static final long serialVersionUID = -8289928767236331716L;
+
+    private final String defaultDatabase;
+    private final String managedTenant;
+    @Nullable private final Pattern hiddenTenantPattern;
+    private final Pattern visibleTenantPattern;
+    private final SchemaType defaultSchemaType;
+    private final int defaultPartitionSize;
+
+    public CatalogConfiguration(Configuration configuration) {
+        super(configuration);
+
+        this.defaultDatabase = get(PULSAR_CATALOG_DEFAULT_DATABASE);
+        this.managedTenant = get(PULSAR_CATALOG_MANAGED_TENANT);
+        this.hiddenTenantPattern = get(PULSAR_CATALOG_HIDDEN_TENANT_PATTERN, Pattern::compile);
+        this.visibleTenantPattern = get(PULSAR_CATALOG_VISIBLE_TENANT_PATTERN, Pattern::compile);
+        this.defaultSchemaType = get(PULSAR_CATALOG_DEFAULT_SCHEMA_TYPE);
+        this.defaultPartitionSize = get(PULSAR_CATALOG_DEFAULT_PARTITION_SIZE);
+
+        // Add extra validation here for falling fast.
+        checkArgument(
+                ALLOWED_SCHEMA_TYPES.contains(defaultSchemaType),
+                "We don't support such schema type: " + defaultSchemaType);
+        checkArgument(defaultPartitionSize > 0, "The partition size should exceed 0");
+    }
+
+    /**
+     * See the description in {@link PulsarCatalogOptions#PULSAR_CATALOG_DEFAULT_DATABASE} for
+     * detailed information.
+     */
+    public String getDefaultDatabase() {
+        return defaultDatabase;
+    }
+
+    /**
+     * See the description in {@link PulsarCatalogOptions#PULSAR_CATALOG_MANAGED_TENANT} for
+     * detailed information.
+     */
+    public String getManagedTenant() {
+        return managedTenant;
+    }
+
+    /**
+     * See the description in {@link PulsarCatalogOptions#PULSAR_CATALOG_DEFAULT_SCHEMA_TYPE} for
+     * detailed information.
+     */
+    public SchemaType getDefaultSchemaType() {
+        return defaultSchemaType;
+    }
+
+    /**
+     * See the description in {@link PulsarCatalogOptions#PULSAR_CATALOG_DEFAULT_PARTITION_SIZE} for
+     * detailed information.
+     */
+    public int getDefaultPartitionSize() {
+        return defaultPartitionSize;
+    }
+
+    /**
+     * Try to accomplish the database name. We will add {@link #managedTenant} for the Flink managed
+     * database.
+     */
+    public String databaseName(String namespace) {
+        if (namespace.contains("/")) {
+            return namespace;
+        } else {
+            return NamespaceName.get(managedTenant, namespace).toString();
+        }
+    }
+
+    /**
+     * Filtering the system namespaces and all the internal tenants. This method will return true if
+     * the given tenant is the managed tenant.
+     *
+     * @param namespace The value from {@link NamespaceName#toString()}
+     */
+    public boolean isInternalDatabase(String namespace) {
+        // This should be a managed database.
+        if (!namespace.contains("/")) {
+            return false;
+        }
+
+        if (isSystemServiceNamespace(namespace)) {
+            return true;
+        }
+
+        NamespaceName namespaceName = NamespaceName.get(namespace);
+        String tenant = namespaceName.getTenant();
+
+        return isInternalTenant(tenant);
+    }
+
+    public boolean isManagedTenant(String tenant) {
+        return managedTenant.equals(tenant)
+                // We also filter the default value of the managed tenant.
+                || PULSAR_CATALOG_MANAGED_TENANT.defaultValue().equals(tenant);
+    }
+
+    public boolean isInternalTenant(String tenant) {
+        if (isManagedTenant(tenant)) {
+            return false;
+        }
+
+        if (hiddenTenantPattern != null && hiddenTenantPattern.matcher(tenant).matches()) {
+            return true;
+        }
+
+        return !visibleTenantPattern.matcher(tenant).matches();
+    }
+
+    public boolean isInternalTable(String database, String table) {
+        if (NAMING_MAPPING_TOPIC.equals(table)) {
+            return true;
+        }
+
+        TopicName topicName = TopicName.get(persistent.value(), NamespaceName.get(database), table);
+        return isSystemTopic(topicName);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        CatalogConfiguration that = (CatalogConfiguration) o;
+        return Objects.equals(defaultDatabase, that.defaultDatabase)
+                && Objects.equals(managedTenant, that.managedTenant)
+                && Objects.equals(hiddenTenantPattern, that.hiddenTenantPattern)
+                && Objects.equals(visibleTenantPattern, that.visibleTenantPattern)
+                && Objects.equals(defaultSchemaType, that.defaultSchemaType)
+                && Objects.equals(defaultPartitionSize, that.defaultPartitionSize);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                super.hashCode(),
+                defaultDatabase,
+                managedTenant,
+                hiddenTenantPattern,
+                visibleTenantPattern,
+                defaultSchemaType,
+                defaultPartitionSize);
+    }
+}

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/table/catalog/config/PulsarCatalogConfigUtils.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/table/catalog/config/PulsarCatalogConfigUtils.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.table.catalog.config;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.connector.pulsar.common.config.PulsarConfigBuilder;
+import org.apache.flink.connector.pulsar.common.config.PulsarConfigValidator;
+import org.apache.flink.connector.pulsar.table.factories.PulsarCatalogFactory;
+import org.apache.flink.table.factories.CatalogFactory;
+import org.apache.flink.table.factories.CatalogFactory.Context;
+import org.apache.flink.table.factories.FactoryUtil.CatalogFactoryHelper;
+import org.apache.flink.table.factories.FactoryUtil.FactoryHelper;
+
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_ADMIN_URL;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_AUTH_PARAMS;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_AUTH_PARAM_MAP;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_SERVICE_URL;
+
+/** Create the {@link CatalogConfiguration} from the {@link Context} and {@link CatalogFactory}. */
+@Internal
+public final class PulsarCatalogConfigUtils {
+
+    public static final PulsarConfigValidator CATALOG_VALIDATOR =
+            PulsarConfigValidator.builder()
+                    .requiredOption(PULSAR_SERVICE_URL)
+                    .requiredOption(PULSAR_ADMIN_URL)
+                    .conflictOptions(PULSAR_AUTH_PARAMS, PULSAR_AUTH_PARAM_MAP)
+                    .build();
+
+    private PulsarCatalogConfigUtils() {
+        // No public constructor
+    }
+
+    /**
+     * A method for creating the config from the catalog factory context. We drop the use of {@link
+     * FactoryHelper} because the Pulsar connector has provided the validation.
+     */
+    public static CatalogConfiguration createConfiguration(
+            PulsarCatalogFactory factory, Context context) {
+        // Validate the catalog config by using flink's configuration.
+        CatalogFactoryHelper helper = new CatalogFactoryHelper(factory, context);
+        helper.validate();
+
+        // Validate the conflict config options which are not supported in Flink catalog helper.
+        PulsarConfigBuilder builder = new PulsarConfigBuilder(context.getOptions());
+        return builder.build(CATALOG_VALIDATOR, CatalogConfiguration::new);
+    }
+}

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/table/catalog/converter/CatalogDatabaseConverter.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/table/catalog/converter/CatalogDatabaseConverter.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.table.catalog.converter;
+
+import org.apache.flink.table.catalog.CatalogDatabase;
+import org.apache.flink.table.catalog.CatalogDatabaseImpl;
+
+import org.apache.flink.shaded.guava30.com.google.common.base.Converter;
+
+import javax.annotation.Nullable;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A converter for converting the {@link CatalogDatabase} to Pulsar namespace properties and
+ * backward converting.
+ */
+public class CatalogDatabaseConverter extends Converter<CatalogDatabase, Map<String, String>> {
+
+    private static final String COMMENT_KEY = "__flink_database_comment";
+    private static final String DESCRIPTION_KEY = "__flink_database_description";
+    private static final String DETAILED_DESCRIPTION_KEY = "__flink_database_detailed_description";
+
+    @Override
+    protected Map<String, String> doForward(CatalogDatabase catalogDatabase) {
+        Map<String, String> properties =
+                Optional.ofNullable(catalogDatabase.getProperties())
+                        .map(HashMap::new)
+                        .orElseGet(HashMap::new);
+
+        Optional.ofNullable(catalogDatabase.getComment())
+                .filter(c -> !c.isEmpty())
+                .ifPresent(comment -> properties.put(COMMENT_KEY, comment));
+
+        catalogDatabase
+                .getDescription()
+                .filter(c -> !c.isEmpty())
+                .ifPresent(description -> properties.put(DESCRIPTION_KEY, description));
+
+        catalogDatabase
+                .getDetailedDescription()
+                .filter(c -> !c.isEmpty())
+                .ifPresent(detailed -> properties.put(DETAILED_DESCRIPTION_KEY, detailed));
+
+        return properties;
+    }
+
+    @Override
+    protected CatalogDatabase doBackward(Map<String, String> properties) {
+        Map<String, String> prop = new HashMap<>(properties);
+        String comment = prop.remove(COMMENT_KEY);
+        String description = prop.remove(DESCRIPTION_KEY);
+        String detailedDescription = prop.remove(DETAILED_DESCRIPTION_KEY);
+
+        return new PulsarCatalogDatabase(prop, comment, description, detailedDescription);
+    }
+
+    /**
+     * An implementation of {@link CatalogDatabase}. We didn't use the default {@link
+     * CatalogDatabaseImpl} for adding the description support.
+     */
+    public static class PulsarCatalogDatabase implements CatalogDatabase {
+
+        private final Map<String, String> properties;
+        private final String comment;
+        private final String description;
+        private final String detailedDescription;
+
+        public PulsarCatalogDatabase(
+                Map<String, String> properties,
+                @Nullable String comment,
+                @Nullable String description,
+                @Nullable String detailedDescription) {
+            this.properties = checkNotNull(properties, "properties cannot be null");
+            this.comment = comment;
+            this.description = description;
+            this.detailedDescription = detailedDescription;
+        }
+
+        @Override
+        public Map<String, String> getProperties() {
+            return properties;
+        }
+
+        @Override
+        public String getComment() {
+            return comment;
+        }
+
+        @Override
+        public CatalogDatabase copy() {
+            return copy(getProperties());
+        }
+
+        @Override
+        public CatalogDatabase copy(Map<String, String> newProperties) {
+            Map<String, String> prop = new HashMap<>(newProperties);
+            return new PulsarCatalogDatabase(prop, comment, description, detailedDescription);
+        }
+
+        @Override
+        public Optional<String> getDescription() {
+            return Optional.ofNullable(description);
+        }
+
+        @Override
+        public Optional<String> getDetailedDescription() {
+            return Optional.ofNullable(detailedDescription);
+        }
+    }
+}

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/table/catalog/converter/CatalogTableConverter.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/table/catalog/converter/CatalogTableConverter.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.table.catalog.converter;
+
+import org.apache.flink.connector.pulsar.table.catalog.config.CatalogConfiguration;
+import org.apache.flink.connector.pulsar.table.schema.SchemaTranslatorUtils;
+import org.apache.flink.table.api.Schema;
+import org.apache.flink.table.catalog.CatalogBaseTable;
+import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.catalog.ResolvedCatalogTable;
+import org.apache.flink.table.catalog.ResolvedSchema;
+
+import org.apache.flink.shaded.guava30.com.google.common.base.Converter;
+
+import org.apache.pulsar.common.schema.SchemaInfo;
+import org.apache.pulsar.common.schema.SchemaType;
+
+import java.util.Map;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+/**
+ * A converter for converting the {@link CatalogBaseTable} to Pulsar topic schema's properties and
+ * backward converting.
+ *
+ * <p>We will support two types of conversion in this tool. They are the tables created by catalog
+ * and the tables that are not created and managed by catalog. We will use an internal flag {@code
+ * FLINK_TABLE_FLAG} in schema properties to mark the related tables as the catalog table.
+ *
+ * <p>All the tables created by the flink catalog will hava a translated schema which matches the
+ * given table columns.
+ */
+@SuppressWarnings("java:S2160")
+public class CatalogTableConverter extends Converter<CatalogBaseTable, SchemaInfo> {
+
+    // An internal flag for marking all the Flink catalog created topics.
+    // We can perform the modification only on these topics.
+    private static final String FLINK_TABLE_FLAG = "__flink_managed_table";
+
+    private final CatalogConfiguration configuration;
+
+    public CatalogTableConverter(CatalogConfiguration configuration) {
+        this.configuration = configuration;
+    }
+
+    @Override
+    protected SchemaInfo doForward(CatalogBaseTable baseTable) {
+        checkArgument(baseTable instanceof ResolvedCatalogTable);
+        ResolvedCatalogTable table = (ResolvedCatalogTable) baseTable;
+
+        Map<String, String> properties = table.toProperties();
+        properties.put(FLINK_TABLE_FLAG, "true");
+
+        // Generate the schema. We will support setting the schema type in the extra options.
+        ResolvedSchema schema = table.getResolvedSchema();
+        SchemaType schemaType = configuration.getDefaultSchemaType();
+
+        return SchemaTranslatorUtils.convert(schema, schemaType);
+    }
+
+    @Override
+    protected CatalogBaseTable doBackward(SchemaInfo info) {
+        if (isFlinkTable(info)) {
+            return CatalogTable.fromProperties(info.getProperties());
+        }
+
+        // This is a Pulsar native table, we will try to convert it into a Flink table.
+        Schema schema = SchemaTranslatorUtils.convert(info);
+        return CatalogTable.of(schema, "", emptyList(), emptyMap());
+    }
+
+    public boolean isFlinkTable(SchemaInfo info) {
+        Map<String, String> properties = info.getProperties();
+        return properties.containsKey(FLINK_TABLE_FLAG);
+    }
+}

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/table/factories/LocalPulsarCatalogFactory.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/table/factories/LocalPulsarCatalogFactory.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.table.factories;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.connector.pulsar.table.catalog.PulsarCatalog;
+import org.apache.flink.connector.pulsar.table.catalog.PulsarCatalogOptions;
+
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * Catalog factory for {@link PulsarCatalog}. This is a catalog factory for local testing purpose.
+ * We will connect to a local Pulsar instance.
+ *
+ * <p>All the required configurations in {@link PulsarCatalogFactory} are no longer required. And
+ * you can't configure these required configurations.
+ */
+@PublicEvolving
+public class LocalPulsarCatalogFactory extends PulsarCatalogFactory {
+
+    @Override
+    public String factoryIdentifier() {
+        return PulsarCatalogOptions.LOCAL_IDENTIFIER;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> requiredOptions() {
+        // Override all the required options in the default Pulsar catalog.
+        return Collections.emptySet();
+    }
+}

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/table/factories/PulsarCatalogFactory.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/table/factories/PulsarCatalogFactory.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.table.factories;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.connector.pulsar.table.catalog.PulsarCatalog;
+import org.apache.flink.connector.pulsar.table.catalog.PulsarCatalogOptions;
+import org.apache.flink.connector.pulsar.table.catalog.config.CatalogConfiguration;
+import org.apache.flink.table.catalog.Catalog;
+import org.apache.flink.table.factories.CatalogFactory;
+
+import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableSet;
+
+import java.util.Set;
+
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_ADMIN_REQUEST_RATES;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_ADMIN_REQUEST_RETRIES;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_ADMIN_REQUEST_WAIT_MILLIS;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_ADMIN_URL;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_AUTH_PARAMS;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_AUTH_PARAM_MAP;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_AUTH_PLUGIN_CLASS_NAME;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_AUTO_CERT_REFRESH_TIME;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_CONCURRENT_LOOKUP_REQUEST;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_CONNECTIONS_PER_BROKER;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_CONNECTION_MAX_IDLE_SECONDS;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_CONNECTION_TIMEOUT_MS;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_CONNECT_TIMEOUT;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_DNS_LOOKUP_BIND_ADDRESS;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_ENABLE_BUSY_WAIT;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_ENABLE_TRANSACTION;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_INITIAL_BACKOFF_INTERVAL_NANOS;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_KEEP_ALIVE_INTERVAL_SECONDS;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_LISTENER_NAME;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_LOOKUP_TIMEOUT_MS;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_MAX_BACKOFF_INTERVAL_NANOS;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_MAX_LOOKUP_REDIRECTS;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_MAX_LOOKUP_REQUEST;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_MAX_NUMBER_OF_REJECTED_REQUEST_PER_CONNECTION;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_MEMORY_LIMIT_BYTES;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_NUM_IO_THREADS;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_NUM_LISTENER_THREADS;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_OPERATION_TIMEOUT_MS;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_PROXY_PROTOCOL;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_PROXY_SERVICE_URL;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_READ_TIMEOUT;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_REQUEST_TIMEOUT;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_REQUEST_TIMEOUT_MS;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_SERVICE_URL;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_SOCKS5_PROXY_ADDRESS;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_SOCKS5_PROXY_PASSWORD;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_SOCKS5_PROXY_USERNAME;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_SSL_PROVIDER;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_STATS_INTERVAL_SECONDS;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_TLS_ALLOW_INSECURE_CONNECTION;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_TLS_CERTIFICATE_FILE_PATH;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_TLS_CIPHERS;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_TLS_HOSTNAME_VERIFICATION_ENABLE;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_TLS_KEY_FILE_PATH;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_TLS_KEY_STORE_PASSWORD;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_TLS_KEY_STORE_PATH;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_TLS_KEY_STORE_TYPE;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_TLS_PROTOCOLS;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_TLS_TRUST_CERTS_FILE_PATH;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_TLS_TRUST_STORE_PASSWORD;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_TLS_TRUST_STORE_PATH;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_TLS_TRUST_STORE_TYPE;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_USE_KEY_STORE_TLS;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_USE_TCP_NO_DELAY;
+import static org.apache.flink.connector.pulsar.table.catalog.PulsarCatalogOptions.PULSAR_CATALOG_DEFAULT_DATABASE;
+import static org.apache.flink.connector.pulsar.table.catalog.PulsarCatalogOptions.PULSAR_CATALOG_DEFAULT_PARTITION_SIZE;
+import static org.apache.flink.connector.pulsar.table.catalog.PulsarCatalogOptions.PULSAR_CATALOG_DEFAULT_SCHEMA_TYPE;
+import static org.apache.flink.connector.pulsar.table.catalog.PulsarCatalogOptions.PULSAR_CATALOG_HIDDEN_TENANT_PATTERN;
+import static org.apache.flink.connector.pulsar.table.catalog.PulsarCatalogOptions.PULSAR_CATALOG_MANAGED_TENANT;
+import static org.apache.flink.connector.pulsar.table.catalog.PulsarCatalogOptions.PULSAR_CATALOG_VISIBLE_TENANT_PATTERN;
+import static org.apache.flink.connector.pulsar.table.catalog.config.PulsarCatalogConfigUtils.createConfiguration;
+
+/** Catalog factory for {@link PulsarCatalog}. */
+@PublicEvolving
+public class PulsarCatalogFactory implements CatalogFactory {
+
+    @Override
+    public String factoryIdentifier() {
+        return PulsarCatalogOptions.IDENTIFIER;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> requiredOptions() {
+        return ImmutableSet.<ConfigOption<?>>builder()
+                .add(PULSAR_SERVICE_URL)
+                .add(PULSAR_ADMIN_URL)
+                .build();
+    }
+
+    @Override
+    public Set<ConfigOption<?>> optionalOptions() {
+        ImmutableSet.Builder<ConfigOption<?>> builder = ImmutableSet.builder();
+
+        // Add the catalog-specified config options.
+        builder.add(PULSAR_CATALOG_DEFAULT_DATABASE)
+                .add(PULSAR_CATALOG_MANAGED_TENANT)
+                .add(PULSAR_CATALOG_HIDDEN_TENANT_PATTERN)
+                .add(PULSAR_CATALOG_VISIBLE_TENANT_PATTERN)
+                .add(PULSAR_CATALOG_DEFAULT_SCHEMA_TYPE)
+                .add(PULSAR_CATALOG_DEFAULT_PARTITION_SIZE);
+
+        // Add all the common config options in PulsarOptions.
+        // Some options are useless now and only used in the Pulsar client.
+        // We add them here for using only the Pulsar client in the future.
+        builder.add(PULSAR_AUTH_PLUGIN_CLASS_NAME)
+                .add(PULSAR_AUTH_PARAMS)
+                .add(PULSAR_AUTH_PARAM_MAP)
+                .add(PULSAR_OPERATION_TIMEOUT_MS)
+                .add(PULSAR_LOOKUP_TIMEOUT_MS)
+                .add(PULSAR_STATS_INTERVAL_SECONDS)
+                .add(PULSAR_NUM_IO_THREADS)
+                .add(PULSAR_NUM_LISTENER_THREADS)
+                .add(PULSAR_CONNECTIONS_PER_BROKER)
+                .add(PULSAR_CONNECTION_MAX_IDLE_SECONDS)
+                .add(PULSAR_USE_TCP_NO_DELAY)
+                .add(PULSAR_TLS_KEY_FILE_PATH)
+                .add(PULSAR_TLS_CERTIFICATE_FILE_PATH)
+                .add(PULSAR_TLS_TRUST_CERTS_FILE_PATH)
+                .add(PULSAR_TLS_ALLOW_INSECURE_CONNECTION)
+                .add(PULSAR_TLS_HOSTNAME_VERIFICATION_ENABLE)
+                .add(PULSAR_CONCURRENT_LOOKUP_REQUEST)
+                .add(PULSAR_MAX_LOOKUP_REQUEST)
+                .add(PULSAR_MAX_LOOKUP_REDIRECTS)
+                .add(PULSAR_MAX_NUMBER_OF_REJECTED_REQUEST_PER_CONNECTION)
+                .add(PULSAR_KEEP_ALIVE_INTERVAL_SECONDS)
+                .add(PULSAR_CONNECTION_TIMEOUT_MS)
+                .add(PULSAR_REQUEST_TIMEOUT_MS)
+                .add(PULSAR_INITIAL_BACKOFF_INTERVAL_NANOS)
+                .add(PULSAR_MAX_BACKOFF_INTERVAL_NANOS)
+                .add(PULSAR_ENABLE_BUSY_WAIT)
+                .add(PULSAR_LISTENER_NAME)
+                .add(PULSAR_USE_KEY_STORE_TLS)
+                .add(PULSAR_SSL_PROVIDER)
+                .add(PULSAR_TLS_KEY_STORE_TYPE)
+                .add(PULSAR_TLS_KEY_STORE_PATH)
+                .add(PULSAR_TLS_KEY_STORE_PASSWORD)
+                .add(PULSAR_TLS_TRUST_STORE_TYPE)
+                .add(PULSAR_TLS_TRUST_STORE_PATH)
+                .add(PULSAR_TLS_TRUST_STORE_PASSWORD)
+                .add(PULSAR_TLS_CIPHERS)
+                .add(PULSAR_TLS_PROTOCOLS)
+                .add(PULSAR_MEMORY_LIMIT_BYTES)
+                .add(PULSAR_PROXY_SERVICE_URL)
+                .add(PULSAR_PROXY_PROTOCOL)
+                .add(PULSAR_ENABLE_TRANSACTION)
+                .add(PULSAR_DNS_LOOKUP_BIND_ADDRESS)
+                .add(PULSAR_SOCKS5_PROXY_ADDRESS)
+                .add(PULSAR_SOCKS5_PROXY_USERNAME)
+                .add(PULSAR_SOCKS5_PROXY_PASSWORD)
+                .add(PULSAR_CONNECT_TIMEOUT)
+                .add(PULSAR_READ_TIMEOUT)
+                .add(PULSAR_REQUEST_TIMEOUT)
+                .add(PULSAR_AUTO_CERT_REFRESH_TIME)
+                .add(PULSAR_ADMIN_REQUEST_RETRIES)
+                .add(PULSAR_ADMIN_REQUEST_WAIT_MILLIS)
+                .add(PULSAR_ADMIN_REQUEST_RATES);
+
+        return builder.build();
+    }
+
+    @Override
+    public Catalog createCatalog(Context context) {
+        CatalogConfiguration configuration = createConfiguration(this, context);
+        return new PulsarCatalog(context.getName(), configuration);
+    }
+}

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/table/schema/SchemaTranslator.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/table/schema/SchemaTranslator.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.table.schema;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.Schema;
+import org.apache.flink.table.catalog.ResolvedSchema;
+
+import org.apache.pulsar.common.schema.SchemaInfo;
+import org.apache.pulsar.common.schema.SchemaType;
+
+/**
+ * Flink's {@link Schema} is used in table API while Pulsar's {@link SchemaInfo} is used for storing
+ * the topic information. We use this translator for converting between these two schemas.
+ */
+@Internal
+public interface SchemaTranslator {
+
+    /** Convert the Pulsar's JSON schema definition into Flink's Schema instance. */
+    Schema toSchema(SchemaInfo info);
+
+    /**
+     * Convert the resolved schema (the schema with type info) into a readable Pulsar schema
+     * definition.
+     */
+    SchemaInfo toSchemaInfo(ResolvedSchema schema);
+
+    /** The supported schema type for this translator. */
+    SchemaType schemaType();
+}

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/table/schema/SchemaTranslatorUtils.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/table/schema/SchemaTranslatorUtils.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.table.schema;
+
+import org.apache.flink.api.common.typeutils.base.InstantSerializer;
+import org.apache.flink.api.common.typeutils.base.LocalDateSerializer;
+import org.apache.flink.api.common.typeutils.base.LocalDateTimeSerializer;
+import org.apache.flink.api.common.typeutils.base.LocalTimeSerializer;
+import org.apache.flink.connector.pulsar.table.schema.translators.AvroSchemaTranslator;
+import org.apache.flink.connector.pulsar.table.schema.translators.JSONSchemaTranslator;
+import org.apache.flink.connector.pulsar.table.schema.translators.PrimitiveSchemaTranslator;
+import org.apache.flink.connector.pulsar.table.schema.translators.ProtobufNativeSchemaTranslator;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.Schema;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.types.DataType;
+
+import org.apache.pulsar.common.schema.SchemaInfo;
+import org.apache.pulsar.common.schema.SchemaType;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.EnumMap;
+import java.util.Map;
+
+import static org.apache.flink.connector.pulsar.common.schema.PulsarSchemaUtils.haveProtobuf;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** Translator between the Flink schema and Pulsar schema. */
+public final class SchemaTranslatorUtils {
+
+    private static final Map<SchemaType, SchemaTranslator> TRANSLATOR_REGISTER =
+            new EnumMap<>(SchemaType.class);
+
+    static {
+        registerSchemaFactory(new AvroSchemaTranslator());
+        registerSchemaFactory(new JSONSchemaTranslator());
+        if (haveProtobuf()) {
+            registerSchemaFactory(new ProtobufNativeSchemaTranslator());
+        }
+        registerPrimitiveFactory(SchemaType.NONE, DataTypes.BYTES());
+        registerPrimitiveFactory(SchemaType.BOOLEAN, DataTypes.BOOLEAN());
+        registerPrimitiveFactory(SchemaType.INT8, DataTypes.TINYINT());
+        registerPrimitiveFactory(SchemaType.INT16, DataTypes.SMALLINT());
+        registerPrimitiveFactory(SchemaType.INT32, DataTypes.INT());
+        registerPrimitiveFactory(SchemaType.INT64, DataTypes.BIGINT());
+        registerPrimitiveFactory(SchemaType.FLOAT, DataTypes.FLOAT());
+        registerPrimitiveFactory(SchemaType.DOUBLE, DataTypes.DOUBLE());
+        registerPrimitiveFactory(SchemaType.BYTES, DataTypes.BYTES());
+        registerPrimitiveFactory(SchemaType.STRING, DataTypes.STRING());
+        registerPrimitiveFactory(SchemaType.TIMESTAMP, DataTypes.TIMESTAMP(3));
+        registerPrimitiveFactory(SchemaType.TIME, DataTypes.TIME());
+        registerPrimitiveFactory(SchemaType.DATE, DataTypes.DATE());
+        registerPrimitiveFactory(
+                SchemaType.INSTANT, DataTypes.RAW(Instant.class, InstantSerializer.INSTANCE));
+        registerPrimitiveFactory(
+                SchemaType.LOCAL_DATE,
+                DataTypes.RAW(LocalDate.class, LocalDateSerializer.INSTANCE));
+        registerPrimitiveFactory(
+                SchemaType.LOCAL_TIME,
+                DataTypes.RAW(LocalTime.class, LocalTimeSerializer.INSTANCE));
+        registerPrimitiveFactory(
+                SchemaType.LOCAL_DATE_TIME,
+                DataTypes.RAW(LocalDateTime.class, LocalDateTimeSerializer.INSTANCE));
+    }
+
+    private SchemaTranslatorUtils() {
+        // No public constructor
+    }
+
+    private static void registerPrimitiveFactory(SchemaType type, DataType dataType) {
+        registerSchemaFactory(new PrimitiveSchemaTranslator(type, dataType));
+    }
+
+    private static void registerSchemaFactory(SchemaTranslator translator) {
+        TRANSLATOR_REGISTER.put(translator.schemaType(), translator);
+    }
+
+    public static Schema convert(SchemaInfo info) {
+        SchemaType type = info.getType();
+        SchemaTranslator translator = TRANSLATOR_REGISTER.get(type);
+        checkNotNull(translator, "We don't support this schema type: " + type);
+
+        return translator.toSchema(info);
+    }
+
+    public static SchemaInfo convert(ResolvedSchema schema, SchemaType type) {
+        SchemaTranslator translator = TRANSLATOR_REGISTER.get(type);
+        checkNotNull(translator, "We don't support this schema type: " + type);
+
+        return translator.toSchemaInfo(schema);
+    }
+}

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/table/schema/translators/AvroSchemaTranslator.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/table/schema/translators/AvroSchemaTranslator.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.table.schema.translators;
+
+import org.apache.flink.connector.pulsar.table.schema.SchemaTranslator;
+import org.apache.flink.formats.avro.typeutils.AvroSchemaConverter;
+import org.apache.flink.table.api.Schema;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.FieldsDataType;
+
+import org.apache.pulsar.client.api.schema.SchemaDefinition;
+import org.apache.pulsar.client.impl.schema.AvroSchema;
+import org.apache.pulsar.client.impl.schema.util.SchemaUtil;
+import org.apache.pulsar.common.schema.SchemaInfo;
+import org.apache.pulsar.common.schema.SchemaType;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.flink.connector.pulsar.table.schema.translators.PrimitiveSchemaTranslator.SINGLE_FIELD_FIELD_NAME;
+import static org.apache.flink.formats.avro.typeutils.AvroSchemaConverter.convertToSchema;
+
+/** The translator for Pulsar's {@link AvroSchema}. */
+public class AvroSchemaTranslator implements SchemaTranslator {
+
+    @Override
+    public Schema toSchema(SchemaInfo info) {
+        String json = new String(info.getSchema(), StandardCharsets.UTF_8);
+        DataType dataType = AvroSchemaConverter.convertToDataType(json);
+        if (!(dataType instanceof FieldsDataType)) {
+            // KeyValue type will be converted into the single value type.
+            return Schema.newBuilder().column(SINGLE_FIELD_FIELD_NAME, dataType).build();
+        }
+
+        return Schema.newBuilder().fromRowDataType(dataType).build();
+    }
+
+    @Override
+    public SchemaInfo toSchemaInfo(ResolvedSchema schema) {
+        SchemaDefinition<?> definition =
+                SchemaDefinition.builder()
+                        .withJSR310ConversionEnabled(true)
+                        .withAlwaysAllowNull(true)
+                        .withJsonDef(schemaJsonDef(schema))
+                        .withSupportSchemaVersioning(true)
+                        .build();
+        return SchemaUtil.parseSchemaInfo(definition, schemaType());
+    }
+
+    private String schemaJsonDef(ResolvedSchema schema) {
+        List<org.apache.avro.Schema> fields = new ArrayList<>(schema.getColumnCount());
+        for (Column column : schema.getColumns()) {
+            org.apache.avro.Schema field =
+                    convertToSchema(column.getDataType().getLogicalType(), column.getName());
+            fields.add(field);
+        }
+
+        return org.apache.avro.Schema.createUnion(fields).toString(false);
+    }
+
+    @Override
+    public SchemaType schemaType() {
+        return SchemaType.AVRO;
+    }
+}

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/table/schema/translators/JSONSchemaTranslator.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/table/schema/translators/JSONSchemaTranslator.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.table.schema.translators;
+
+import org.apache.pulsar.client.impl.schema.JSONSchema;
+import org.apache.pulsar.common.schema.SchemaType;
+
+/** The translator for Pulsar's {@link JSONSchema}. */
+public class JSONSchemaTranslator extends AvroSchemaTranslator {
+
+    @Override
+    public SchemaType schemaType() {
+        return SchemaType.JSON;
+    }
+}

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/table/schema/translators/PrimitiveSchemaTranslator.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/table/schema/translators/PrimitiveSchemaTranslator.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.table.schema.translators;
+
+import org.apache.flink.connector.pulsar.table.schema.SchemaTranslator;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.DataTypes.Field;
+import org.apache.flink.table.api.Schema;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.types.DataType;
+
+import org.apache.pulsar.common.schema.SchemaInfo;
+import org.apache.pulsar.common.schema.SchemaType;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+/**
+ * The translator for pulsar's primitive types. Currently, Pulsar supports <a
+ * href="https://pulsar.apache.org/docs/en/schema-understand/#primitive-type">these primitive
+ * types</a>.
+ */
+public class PrimitiveSchemaTranslator implements SchemaTranslator {
+
+    public static final String SINGLE_FIELD_FIELD_NAME = "value";
+
+    private final SchemaType schemaType;
+    private final DataType dataType;
+
+    public PrimitiveSchemaTranslator(SchemaType schemaType, DataType dataType) {
+        checkArgument(schemaType.isPrimitive());
+
+        this.schemaType = schemaType;
+        this.dataType = dataType;
+    }
+
+    @Override
+    public Schema toSchema(SchemaInfo info) {
+        Field field = DataTypes.FIELD(SINGLE_FIELD_FIELD_NAME, dataType);
+        return Schema.newBuilder().fromRowDataType(DataTypes.ROW(field)).build();
+    }
+
+    @Override
+    public SchemaInfo toSchemaInfo(ResolvedSchema schema) {
+        throw new UnsupportedOperationException(
+                "Primitive Pulsar schema can't be generated from Flink schema.");
+    }
+
+    @Override
+    public SchemaType schemaType() {
+        return schemaType;
+    }
+}

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/table/schema/translators/ProtobufNativeSchemaTranslator.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/table/schema/translators/ProtobufNativeSchemaTranslator.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.table.schema.translators;
+
+import org.apache.flink.connector.pulsar.table.schema.SchemaTranslator;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.DataTypes.Field;
+import org.apache.flink.table.api.Schema;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.types.DataType;
+
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.Descriptors.FieldDescriptor;
+import org.apache.pulsar.client.impl.schema.ProtobufNativeSchema;
+import org.apache.pulsar.client.impl.schema.ProtobufNativeSchemaUtils;
+import org.apache.pulsar.common.schema.SchemaInfo;
+import org.apache.pulsar.common.schema.SchemaType;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** The translator for Pulsar's {@link ProtobufNativeSchema} schema. */
+public class ProtobufNativeSchemaTranslator implements SchemaTranslator {
+
+    @Override
+    public Schema toSchema(SchemaInfo info) {
+        Descriptor descriptor = ProtobufNativeSchemaUtils.deserialize(info.getSchema());
+        DataType dataType = descriptorToDataType(descriptor);
+
+        return Schema.newBuilder().fromRowDataType(dataType).build();
+    }
+
+    public static DataType descriptorToDataType(Descriptor descriptor) {
+        List<Field> fields = new ArrayList<>();
+        List<FieldDescriptor> protoFields = descriptor.getFields();
+
+        for (FieldDescriptor fieldDescriptor : protoFields) {
+            DataType fieldType = fieldDescriptorToDataType(fieldDescriptor);
+            fields.add(DataTypes.FIELD(fieldDescriptor.getName(), fieldType));
+        }
+
+        if (fields.isEmpty()) {
+            throw new IllegalArgumentException("No FieldDescriptors found");
+        }
+
+        return DataTypes.ROW(fields.toArray(new Field[0]));
+    }
+
+    private static DataType fieldDescriptorToDataType(FieldDescriptor field) {
+        FieldDescriptor.JavaType type = field.getJavaType();
+        DataType dataType;
+        switch (type) {
+            case BOOLEAN:
+                dataType = DataTypes.BOOLEAN();
+                break;
+            case BYTE_STRING:
+                dataType = DataTypes.BYTES();
+                break;
+            case DOUBLE:
+                dataType = DataTypes.DOUBLE();
+                break;
+            case ENUM:
+            case STRING:
+                dataType = DataTypes.STRING();
+                break;
+            case FLOAT:
+                dataType = DataTypes.FLOAT();
+                break;
+            case INT:
+                dataType = DataTypes.INT();
+                break;
+            case LONG:
+                dataType = DataTypes.BIGINT();
+                break;
+            case MESSAGE:
+                Descriptors.Descriptor msg = field.getMessageType();
+                if (field.isMapField()) {
+                    // map
+                    DataType key = fieldDescriptorToDataType(msg.findFieldByName("key"));
+                    DataType value = fieldDescriptorToDataType(msg.findFieldByName("value"));
+                    dataType = DataTypes.MAP(key, value);
+                } else {
+                    // row
+                    dataType = descriptorToDataType(field.getMessageType());
+                }
+                break;
+            default:
+                throw new IllegalArgumentException(
+                        "Unknown type: " + type + " for FieldDescriptor: " + field);
+        }
+
+        // list
+        if (field.isRepeated() && !field.isMapField()) {
+            return DataTypes.ARRAY(dataType);
+        }
+
+        // single value
+        return dataType;
+    }
+
+    @Override
+    public SchemaInfo toSchemaInfo(ResolvedSchema schema) {
+        throw new UnsupportedOperationException(
+                "Pulsar protobuf schema can't be generated from Flink schema.");
+    }
+
+    @Override
+    public SchemaType schemaType() {
+        return SchemaType.PROTOBUF_NATIVE;
+    }
+}

--- a/flink-connector-pulsar/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/flink-connector-pulsar/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.connector.pulsar.table.factories.LocalPulsarCatalogFactory
+org.apache.flink.connector.pulsar.table.factories.PulsarCatalogFactory

--- a/pom.xml
+++ b/pom.xml
@@ -272,6 +272,12 @@ under the License.
 
             <dependency>
                 <groupId>org.apache.flink</groupId>
+                <artifactId>flink-table-api-java-bridge</artifactId>
+                <version>${flink.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.flink</groupId>
                 <artifactId>flink-avro</artifactId>
                 <version>${flink.version}</version>
             </dependency>
@@ -279,6 +285,12 @@ under the License.
             <dependency>
                 <groupId>org.apache.flink</groupId>
                 <artifactId>flink-json</artifactId>
+                <version>${flink.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.flink</groupId>
+                <artifactId>flink-protobuf</artifactId>
                 <version>${flink.version}</version>
             </dependency>
 


### PR DESCRIPTION
## Purpose of the change

This PR will make the Pulsar serve as the Flink catalog backend. It will expose the Pulsar's namespace as the Flink's database, the Pulsar's topic as the Flink's table. You can easily create any tables and databases on Pulsar. The tables created by Flink can be consumed by other Pulsar clients with a valid schema check.

## Brief change log

- Support both `Duration` and numeric time in `PulsarConfiguration` class, which make the existing config options can be configured with a time str in Table API.
- Alter all the existing time related config options to use `useDuration` method.
- Initial `PulsarCatalog` implementation with new config model and schema translator and etc.

## Verifying this change

This change doesn't contains any tests, it's a initial implementation which won't be used by any user. We will add tests in upcoming PRs.

## Significant changes

- [x] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [x] New feature has been introduced
    - If yes, how is this documented? (not documented)
