### PR TITLE
[hotfix] Fix connector artifact shortcode for document.

### DIFF
--- a/docs/content.zh/docs/connectors/datastream/pulsar.md
+++ b/docs/content.zh/docs/connectors/datastream/pulsar.md
@@ -32,7 +32,7 @@ Pulsar Source 当前支持 Pulsar 2.8.1 之后的版本，但是 Pulsar Source �
 
 如果想要了解更多关于 Pulsar API 兼容性设计，可以阅读文档 [PIP-72](https://github.com/apache/pulsar/wiki/PIP-72%3A-Introduce-Pulsar-Interface-Taxonomy%3A-Audience-and-Stability-Classification)。
 
-{{< artifact flink-connector-pulsar >}}
+{{< connector_artifact flink-connector-pulsar 3.0.0 >}}
 
 {{< py_download_link "pulsar" >}}
 

--- a/docs/content/docs/connectors/datastream/pulsar.md
+++ b/docs/content/docs/connectors/datastream/pulsar.md
@@ -32,7 +32,7 @@ You can use the connector with the Pulsar 2.8.1 or higher. Because the Pulsar co
 Pulsar [transactions](https://pulsar.apache.org/docs/en/txn-what/), it is recommended to use the Pulsar 2.9.2 or higher.
 Details on Pulsar compatibility can be found in [PIP-72](https://github.com/apache/pulsar/wiki/PIP-72%3A-Introduce-Pulsar-Interface-Taxonomy%3A-Audience-and-Stability-Classification).
 
-{{< artifact flink-connector-pulsar >}}
+{{< connector_artifact flink-connector-pulsar 3.0.0 >}}
 
 {{< py_download_link "pulsar" >}}
 


### PR DESCRIPTION
## Purpose of the change

*Fix connector artifact shortcode for v3.0 branch document.*

## Brief change log

- Using `connector_artifact` instead of `artifact`.

## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.


## Significant changes

- [ ] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [ ] New feature has been introduced
    - If yes, how is this documented? (not applicable / docs / JavaDocs / not documented)
