### PR TITLE
[FLINK-32003] Upgrade pulsar-client version to work with OAuth2

### DIFF
--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/schema/PulsarSchema.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/schema/PulsarSchema.java
@@ -155,6 +155,9 @@ public final class PulsarSchema<T> implements Serializable {
             oos.writeUTF(entry.getKey());
             oos.writeUTF(entry.getValue());
         }
+
+        // Timestamp
+        oos.writeLong(schemaInfo.getTimestamp());
     }
 
     private void readObject(ObjectInputStream ois) throws ClassNotFoundException, IOException {
@@ -177,12 +180,16 @@ public final class PulsarSchema<T> implements Serializable {
             properties.put(ois.readUTF(), ois.readUTF());
         }
 
+        // Timestamp
+        long timestamp = ois.readLong();
+
         this.schemaInfo =
                 SchemaInfoImpl.builder()
                         .name(name)
                         .schema(schemaBytes)
                         .type(type)
                         .properties(properties)
+                        .timestamp(timestamp)
                         .build();
         this.schema = createSchema(schemaInfo);
     }

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/schema/PulsarSchema.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/schema/PulsarSchema.java
@@ -177,12 +177,13 @@ public final class PulsarSchema<T> implements Serializable {
             properties.put(ois.readUTF(), ois.readUTF());
         }
 
-        this.schemaInfo = SchemaInfoImpl.builder()
-                .name(name)
-                .schema(schemaBytes)
-                .type(type)
-                .properties(properties)
-                .build();
+        this.schemaInfo =
+                SchemaInfoImpl.builder()
+                        .name(name)
+                        .schema(schemaBytes)
+                        .type(type)
+                        .properties(properties)
+                        .build();
         this.schema = createSchema(schemaInfo);
     }
 

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/schema/PulsarSchema.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/schema/PulsarSchema.java
@@ -177,7 +177,12 @@ public final class PulsarSchema<T> implements Serializable {
             properties.put(ois.readUTF(), ois.readUTF());
         }
 
-        this.schemaInfo = new SchemaInfoImpl(name, schemaBytes, type, properties);
+        this.schemaInfo = SchemaInfoImpl.builder()
+                .name(name)
+                .schema(schemaBytes)
+                .type(type)
+                .properties(properties)
+                .build();
         this.schema = createSchema(schemaInfo);
     }
 

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/schema/PulsarSchemaUtils.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/schema/PulsarSchemaUtils.java
@@ -131,7 +131,9 @@ public final class PulsarSchemaUtils {
         // No need to create instance.
     }
 
-    /** A boolean value for determine if user have protobuf-java in his class path. */
+    /**
+     * A boolean value for determine if user have protobuf-java in his class path.
+     */
     public static boolean haveProtobuf() {
         return PROTOBUF_MESSAGE_CLASS != null;
     }
@@ -181,8 +183,12 @@ public final class PulsarSchemaUtils {
         Map<String, String> properties = new HashMap<>(schemaInfo.getProperties());
         properties.put(CLASS_INFO_PLACEHOLDER, typeClass.getName());
 
-        return new SchemaInfoImpl(
-                schemaInfo.getName(), schemaInfo.getSchema(), schemaInfo.getType(), properties);
+        return SchemaInfoImpl.builder()
+                .name(schemaInfo.getName())
+                .schema(schemaInfo.getSchema())
+                .type(schemaInfo.getType())
+                .properties(properties)
+                .build();
     }
 
     @SuppressWarnings("unchecked")

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/schema/PulsarSchemaUtils.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/schema/PulsarSchemaUtils.java
@@ -131,9 +131,7 @@ public final class PulsarSchemaUtils {
         // No need to create instance.
     }
 
-    /**
-     * A boolean value for determine if user have protobuf-java in his class path.
-     */
+    /** A boolean value for determine if user have protobuf-java in his class path. */
     public static boolean haveProtobuf() {
         return PROTOBUF_MESSAGE_CLASS != null;
     }

--- a/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/runtime/container/PulsarContainerRuntime.java
+++ b/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/runtime/container/PulsarContainerRuntime.java
@@ -54,8 +54,8 @@ public class PulsarContainerRuntime implements PulsarRuntime {
             String.format("http://%s:%d", PULSAR_INTERNAL_HOSTNAME, BROKER_HTTP_PORT);
 
     /**
-     * Create a pulsar container provider by a predefined version, this constant
-     * should be bumped after the new pulsar release.
+     * Create a pulsar container provider by a predefined version, this constant should be bumped
+     * after the new pulsar release.
      */
     public static final String PULSAR = "apachepulsar/pulsar:2.10.2";
 

--- a/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/runtime/container/PulsarContainerRuntime.java
+++ b/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/runtime/container/PulsarContainerRuntime.java
@@ -20,7 +20,6 @@ package org.apache.flink.connector.pulsar.testutils.runtime.container;
 
 import org.apache.flink.connector.pulsar.testutils.runtime.PulsarRuntime;
 import org.apache.flink.connector.pulsar.testutils.runtime.PulsarRuntimeOperator;
-import org.apache.flink.util.DockerImageVersions;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/runtime/container/PulsarContainerRuntime.java
+++ b/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/runtime/container/PulsarContainerRuntime.java
@@ -32,7 +32,6 @@ import org.testcontainers.utility.DockerImageName;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.apache.flink.util.DockerImageVersions.PULSAR;
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.testcontainers.containers.PulsarContainer.BROKER_HTTP_PORT;
@@ -56,9 +55,11 @@ public class PulsarContainerRuntime implements PulsarRuntime {
             String.format("http://%s:%d", PULSAR_INTERNAL_HOSTNAME, BROKER_HTTP_PORT);
 
     /**
-     * Create a pulsar container provider by a predefined version, this constance {@link
-     * DockerImageVersions#PULSAR} should be bumped after the new pulsar release.
+     * Create a pulsar container provider by a predefined version, this constant
+     * should be bumped after the new pulsar release.
      */
+    public static final String PULSAR = "apachepulsar/pulsar:2.10.2";
+
     private final PulsarContainer container = new PulsarContainer(DockerImageName.parse(PULSAR));
 
     private final AtomicBoolean started = new AtomicBoolean(false);

--- a/flink-sql-connector-pulsar/src/main/resources/META-INF/NOTICE
+++ b/flink-sql-connector-pulsar/src/main/resources/META-INF/NOTICE
@@ -6,10 +6,10 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- org.apache.pulsar:bouncy-castle-bc:pkg:2.10.1
-- org.apache.pulsar:pulsar-client-admin-api:2.10.1
-- org.apache.pulsar:pulsar-client-all:2.10.1
-- org.apache.pulsar:pulsar-client-api:2.10.1
+- org.apache.pulsar:bouncy-castle-bc:pkg:2.10.2
+- org.apache.pulsar:pulsar-client-admin-api:2.10.2
+- org.apache.pulsar:pulsar-client-all:2.10.2
+- org.apache.pulsar:pulsar-client-api:2.10.2
 - org.slf4j:jul-to-slf4j:1.7.32
 
 This project bundles the following dependencies under the Bouncy Castle license.

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@ under the License.
 
     <properties>
         <flink.version>1.16.0</flink.version>
-        <pulsar.version>2.10.1</pulsar.version>
+        <pulsar.version>2.10.2</pulsar.version>
 
         <jackson-bom.version>2.13.4.20221013</jackson-bom.version>
         <grpc-bom.version>1.45.1</grpc-bom.version>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@ under the License.
         <grpc-bom.version>1.45.1</grpc-bom.version>
         <bouncycastle.version>1.69</bouncycastle.version>
         <google.auth.version>1.4.0</google.auth.version>
-        <jetty.version>9.4.44.v20210927</jetty.version>
+        <jetty.version>9.4.48.v20220622</jetty.version>
         <simpleclient.version>0.8.1</simpleclient.version>
         <junit4.version>4.13.2</junit4.version>
         <junit5.version>5.8.1</junit5.version>


### PR DESCRIPTION
## Purpose of the change

Upgrade pulsar-client version to work with OAuth2

## Verifying this change

Existing tests should pass.

## Significant changes

*(Please check any boxes [x] if the answer is "yes". You can first publish the PR and check them afterwards, for
convenience.)*

- [x] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [ ] New feature has been introduced
    - If yes, how is this documented? (not applicable / docs / JavaDocs / not documented)
