### PR TITLE
[hotfix] Python connector download link should refer to the url defined in externalized repository

### DIFF
--- a/docs/content.zh/docs/connectors/datastream/pulsar.md
+++ b/docs/content.zh/docs/connectors/datastream/pulsar.md
@@ -32,7 +32,7 @@ Flink 当前提供 [Apache Pulsar](https://pulsar.apache.org) Source 和 Sink �
 
 {{< connector_artifact flink-connector-pulsar 4.0.0-SNAPSHOT >}}
 
-{{< py_download_link "pulsar" >}}
+{{< py_connector_download_link "pulsar" 4.0.0-SNAPSHOT >}}
 
 Flink 的流连接器并不会放到发行文件里面一同发布，阅读[此文档]({{< ref "docs/dev/configuration/overview" >}})，了解如何将连接器添加到集群实例内。
 

--- a/docs/content/docs/connectors/datastream/pulsar.md
+++ b/docs/content/docs/connectors/datastream/pulsar.md
@@ -33,7 +33,7 @@ The details on Pulsar compatibility can be found in [PIP-72](https://github.com/
 
 {{< connector_artifact flink-connector-pulsar 4.0.0-SNAPSHOT >}}
 
-{{< py_download_link "pulsar" >}}
+{{< py_connector_download_link "pulsar" 4.0.0-SNAPSHOT >}}
 
 Flink's streaming connectors are not part of the binary distribution.
 See how to link with them for cluster execution [here]({{< ref "docs/dev/configuration/overview" >}}).

--- a/docs/data/pulsar.yml
+++ b/docs/data/pulsar.yml
@@ -1,0 +1,21 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+variants:
+  - maven: flink-connector-pulsar
+    sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-pulsar/$full_version/flink-sql-connector-pulsar-$full_version.jar


### PR DESCRIPTION
## Purpose of the change

*Python connector download link should refer to the url defined in externalized repository.*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Significant changes

*(Please check any boxes [x] if the answer is "yes". You can first publish the PR and check them afterwards, for
convenience.)*

- [ ] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [ ] New feature has been introduced
    - If yes, how is this documented? (not applicable / docs / JavaDocs / not documented)
