### PR TITLE
[BP-4.0][FLINK-32024][docs] Short code related to externalized connector retrieve version from its own data yaml

### DIFF
--- a/docs/content.zh/docs/connectors/datastream/pulsar.md
+++ b/docs/content.zh/docs/connectors/datastream/pulsar.md
@@ -30,9 +30,9 @@ Flink 当前提供 [Apache Pulsar](https://pulsar.apache.org) Source 和 Sink �
 
 当前支持 Pulsar 2.10.0 及其之后的版本，建议在总是将 Pulsar 升级至最新版。如果想要了解更多关于 Pulsar API 兼容性设计，可以阅读文档 [PIP-72](https://github.com/apache/pulsar/wiki/PIP-72%3A-Introduce-Pulsar-Interface-Taxonomy%3A-Audience-and-Stability-Classification)。
 
-{{< connector_artifact flink-connector-pulsar 4.0.0 >}}
+{{< connector_artifact flink-connector-pulsar pulsar >}}
 
-{{< py_connector_download_link "pulsar" 4.0.0 >}}
+{{< py_connector_download_link "pulsar" >}}
 
 Flink 的流连接器并不会放到发行文件里面一同发布，阅读[此文档]({{< ref "docs/dev/configuration/overview" >}})，了解如何将连接器添加到集群实例内。
 

--- a/docs/content/docs/connectors/datastream/pulsar.md
+++ b/docs/content/docs/connectors/datastream/pulsar.md
@@ -31,9 +31,9 @@ Flink provides an [Apache Pulsar](https://pulsar.apache.org) connector for readi
 You can use the connector with the Pulsar 2.10.0 or higher. It is recommended to always use the latest Pulsar version.
 The details on Pulsar compatibility can be found in [PIP-72](https://github.com/apache/pulsar/wiki/PIP-72%3A-Introduce-Pulsar-Interface-Taxonomy%3A-Audience-and-Stability-Classification).
 
-{{< connector_artifact flink-connector-pulsar 4.0.0 >}}
+{{< connector_artifact flink-connector-pulsar pulsar >}}
 
-{{< py_connector_download_link "pulsar" 4.0.0 >}}
+{{< py_connector_download_link "pulsar" >}}
 
 Flink's streaming connectors are not part of the binary distribution.
 See how to link with them for cluster execution [here]({{< ref "docs/dev/configuration/overview" >}}).

--- a/docs/data/pulsar.yml
+++ b/docs/data/pulsar.yml
@@ -16,6 +16,7 @@
 # limitations under the License.
 ################################################################################
 
+version: 4.0.0
 variants:
   - maven: flink-connector-pulsar
     sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-pulsar/$full_version/flink-sql-connector-pulsar-$full_version.jar


### PR DESCRIPTION
Backport to `v4.0` as flink track this branch to render documentation.