### PR TITLE
[FLINK-30400][build] Stop bundling flink-connector-base

### DIFF
--- a/flink-connector-pulsar-e2e-tests/pom.xml
+++ b/flink-connector-pulsar-e2e-tests/pom.xml
@@ -54,6 +54,12 @@ under the License.
 			<groupId>org.testcontainers</groupId>
 			<artifactId>pulsar</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-base</artifactId>
+			<version>${flink.version}</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<profiles>

--- a/flink-connector-pulsar/pom.xml
+++ b/flink-connector-pulsar/pom.xml
@@ -41,6 +41,7 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-connector-base</artifactId>
+                        <scope>provided</scope>
 		</dependency>
 
 		<!-- Connectors -->

--- a/flink-sql-connector-pulsar/pom.xml
+++ b/flink-sql-connector-pulsar/pom.xml
@@ -66,7 +66,6 @@ under the License.
 							<artifactSet>
 								<includes>
 									<include>com.fasterxml.jackson.core:jackson-annotations</include>
-									<include>org.apache.flink:flink-connector-base</include>
 									<include>org.apache.flink:flink-connector-pulsar</include>
 									<include>org.apache.pulsar:pulsar-client-admin-api</include>
 									<include>org.apache.pulsar:pulsar-client-all</include>

--- a/flink-sql-connector-pulsar/pom.xml
+++ b/flink-sql-connector-pulsar/pom.xml
@@ -48,6 +48,12 @@ under the License.
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-annotations</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-base</artifactId>
+			<version>${flink.version}</version>
+			<scope>provided</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -273,6 +273,7 @@ under the License.
                 <groupId>org.apache.flink</groupId>
                 <artifactId>flink-connector-base</artifactId>
                 <version>${flink.version}</version>
+                <scope>provided</scope>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
## Purpose of the change

Stop bundling flink-connector-base.

Ref - FLINK-30400

## Verifying this change

This change is a code cleanup without any test coverage.

## Significant changes

- [x] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [ ] New feature has been introduced
    - If yes, how is this documented? (not applicable / docs / JavaDocs / not documented)
