### PR TITLE
[hotfix] Be Compatible with Flink 1.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,11 @@ concurrency:
 
 jobs:
   compile_and_test:
+    strategy:
+      matrix:
+        flink: [ 1.16.2, 1.17.1 ]
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:
-      flink_version: 1.17.0
+      flink_version: ${{ matrix.flink }}
       timeout_global: 120
       timeout_test: 80


### PR DESCRIPTION
## Purpose of the change

We forget to check 1.16 compile compatibility and it fails v4.1 release.

## Brief change log

- *Change the internal design of `ProducerRegister`.*
- *Expose topic metadata query in `PulsarSinkContext`.*
- *Change the internal metadata cache in `MetadataListener`.*

## Verifying this change

Existing tests should work.

## Significant changes

*(Please check any boxes [x] if the answer is "yes". You can first publish the PR and check them afterwards, for
convenience.)*

- [ ] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [ ] New feature has been introduced
    - If yes, how is this documented? (not applicable / docs / JavaDocs / not documented)
