### PR TITLE
[FLINK-33815][Connector / Pulsar] Add tests against jdk17 for pulsar connector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,14 @@ jobs:
   compile_and_test:
     strategy:
       matrix:
-        flink: [ 1.17.0, 1.18.0 ]
+        flink: [ 1.17.1, 1.18.0 ]
+        jdk: [ 8, 11, 17 ]
+        exclude:
+          - jdk: 17
+            flink: 1.17.1
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:
       flink_version: ${{ matrix.flink }}
+      jdk_version: ${{ matrix.jdk }}
       timeout_global: 120
       timeout_test: 80

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -28,6 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        jdk: [ 8, 11 ]
         flink_branches: [{
           flink: 1.17-SNAPSHOT,
           branch: main
@@ -41,8 +42,15 @@ jobs:
           flink: 1.17.1,
           branch: v4.0
         }]
+        include:
+          - jdk: 17
+            flink_branches: [ {
+              flink: 1.18-SNAPSHOT,
+              branch: main
+            }]
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:
+      jdk_version: ${{ matrix.jdk }}
       flink_version: ${{ matrix.flink_branches.flink }}
       connector_branch: ${{ matrix.flink_branches.branch }}
       run_dependency_convergence: false


### PR DESCRIPTION
## Purpose of the change

1.18.x supports jdk 17, so it would make sense to add tests against java 17

## Brief change log

gha

## Verifying this change



This change is a trivial rework 

## Significant changes

- [ ] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [ ] New feature has been introduced
    - If yes, how is this documented? (not applicable / docs / JavaDocs / not documented)
