### PR TITLE
[FLINK-34629] Fix invalid subtask assignment for non-partitioned topics

### DIFF
--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/assigner/SplitAssignerImpl.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/assigner/SplitAssignerImpl.java
@@ -159,13 +159,17 @@ class SplitAssignerImpl implements SplitAssigner {
                 partition.getTopic(), partition.getPartitionId(), context.currentParallelism());
     }
 
+    /**
+     * Calculate the partition owner by the topic name, partition id, and parallelism.
+     *
+     * @param topic The topic name.
+     * @param partitionId The partition id.
+     * @param parallelism The parallelism.
+     * @return The id of the reader that owns this partition.
+     */
     @VisibleForTesting
     static int calculatePartitionOwner(String topic, int partitionId, int parallelism) {
         int startIndex = ((topic.hashCode() * 31) & 0x7FFFFFFF) % parallelism;
-        /*
-         * Here, the assumption is that the id of Pulsar partitions are always ascending starting from
-         * 0. Therefore, can be used directly as the offset clockwise from the start index.
-         */
-        return (startIndex + partitionId) % parallelism;
+        return Math.floorMod(startIndex + partitionId, parallelism);
     }
 }


### PR DESCRIPTION
<!--
*Thank you for contributing to Apache Flink Pulsar Connectors - we are happy that you want to help us improve our Flink connectors. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

- The name of the pull request should correspond to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
- Commits should be in the form of "[FLINK-XXXX][Component] Title of the pull request", where [FLINK-XXXX] should be replaced by the actual issue number.
    Generally, [Component] tag should indicate the part you modified. The options are: [Stream | Table | Test | E2E | Build].
    For example: "[FLINK-XXXX][Stream] XXXX" if you are working on the `DataStream` part of pulsar connector or "[FLINK-XXXX][Test] XXXX" if this pull request is only used for adding tests.
- Each pull request should only have one JIRA issue.
- Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

## Purpose of the change
This PR fixes a bug in partition owner logic returning `-1` for the partition owner, and is an alternative fix to the one proposed in https://github.com/apache/flink-connector-pulsar/pull/84. 

The subtask ID to which we try to assign a split should always be within `[0, parallelism-1]`. The bug occurs because a non-partitioned topic has `partitionId = -1` and the hash logic for certain topic names will yield `startIndex = 0`. Since the `%` operator can return negative values, the owner ID returned is `-1`. Replacing `%` with `floorMod` fixes this issue.

## Brief change log

- Use `floorMod` instead of `%` so that `calculatePartitionOwner` cannot return a negative value.

## Verifying this change

This change added tests and can be verified as follows:

- Unit test to check that a split is assigned for different non-partitioned topic names and parallelism values. This test fails without the fix.


## Significant changes

- [ ] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [ ] New feature has been introduced
    - If yes, how is this documented? (not applicable / docs / JavaDocs / not documented)
