### PR TITLE
[upgrade] fink to 1.18.1 and pulsar to 3.0.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
   compile_and_test:
     strategy:
       matrix:
-        flink: [ 1.17.1, 1.18.0 ]
+        flink: [ 1.17.1, 1.18.1 ]
         jdk: [ 8, 11, 17 ]
         exclude:
           - jdk: 17

--- a/docs/content.zh/docs/connectors/datastream/pulsar.md
+++ b/docs/content.zh/docs/connectors/datastream/pulsar.md
@@ -28,7 +28,7 @@ Flink 当前提供 [Apache Pulsar](https://pulsar.apache.org) Source 和 Sink �
 
 ## 添加依赖
 
-当前支持 Pulsar 3.0.0 及其之后的版本，建议总是将 Pulsar 升级至最新版。如果想要了解更多对于 Pulsar API 兼容性设计，可以阅读文档 [PIP-72](https://github.com/apache/pulsar/wiki/PIP-72%3A-Introduce-Pulsar-Interface-Taxonomy%3A-Audience-and-Stability-Classification)。
+当前支持 Pulsar 3.0.4 及其之后的版本，建议总是将 Pulsar 升级至最新版。如果想要了解更多对于 Pulsar API 兼容性设计，可以阅读文档 [PIP-72](https://github.com/apache/pulsar/wiki/PIP-72%3A-Introduce-Pulsar-Interface-Taxonomy%3A-Audience-and-Stability-Classification)。
 
 {{< connector_artifact flink-connector-pulsar pulsar >}}
 

--- a/docs/content/docs/connectors/datastream/pulsar.md
+++ b/docs/content/docs/connectors/datastream/pulsar.md
@@ -28,7 +28,7 @@ Flink provides an [Apache Pulsar](https://pulsar.apache.org) connector for readi
 
 ## Dependency
 
-You can use the connector with the Pulsar 3.0.0 or higher. It is recommended to always use the latest Pulsar version.
+You can use the connector with the Pulsar 3.0.4 or higher. It is recommended to always use the latest Pulsar version.
 The details on Pulsar compatibility can be found in [PIP-72](https://github.com/apache/pulsar/wiki/PIP-72%3A-Introduce-Pulsar-Interface-Taxonomy%3A-Audience-and-Stability-Classification).
 
 {{< connector_artifact flink-connector-pulsar pulsar >}}

--- a/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/runtime/container/PulsarContainerRuntime.java
+++ b/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/runtime/container/PulsarContainerRuntime.java
@@ -54,7 +54,7 @@ public class PulsarContainerRuntime implements PulsarRuntime {
     private static final String PULSAR_ADMIN_URL =
             String.format("http://%s:%d", PULSAR_INTERNAL_HOSTNAME, BROKER_HTTP_PORT);
 
-    private static final String CURRENT_VERSION = "3.0.0";
+    private static final String CURRENT_VERSION = "3.0.4";
 
     private final PulsarContainer container;
     private final AtomicBoolean started;

--- a/flink-sql-connector-pulsar/src/main/resources/META-INF/NOTICE
+++ b/flink-sql-connector-pulsar/src/main/resources/META-INF/NOTICE
@@ -7,9 +7,9 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - com.fasterxml.jackson.core:jackson-annotations:2.13.4
-- org.apache.pulsar:pulsar-client-admin-api:3.0.0
-- org.apache.pulsar:pulsar-client-all:3.0.0
-- org.apache.pulsar:pulsar-client-api:3.0.0
+- org.apache.pulsar:pulsar-client-admin-api:3.0.4
+- org.apache.pulsar:pulsar-client-all:3.0.4
+- org.apache.pulsar:pulsar-client-api:3.0.4
 
 This project bundles the following dependencies under the Bouncy Castle license.
 See bundled license files for details.

--- a/pom.xml
+++ b/pom.xml
@@ -51,9 +51,9 @@ under the License.
     </modules>
 
     <properties>
-        <flink.version>1.18.0</flink.version>
-        <flink-ci-tools.version>1.18.0</flink-ci-tools.version>
-        <pulsar.version>3.0.0</pulsar.version>
+        <flink.version>1.18.1</flink.version>
+        <flink-ci-tools.version>1.18.1</flink-ci-tools.version>
+        <pulsar.version>3.0.4</pulsar.version>
         <scala.binary.version>2.12</scala.binary.version>
         <bouncycastle.version>1.69</bouncycastle.version>
 


### PR DESCRIPTION
## Purpose of the change

Upgrade fink and pulsar to LTS new version.

## Brief change log
-  fink to 1.18.1 
- pulsar to 3.0.4

## Verifying this change
This change is an upgrade, look current ci if pass.

## Significant changes

*(Please check any boxes [x] if the answer is "yes". You can first publish the PR and check them afterwards, for
convenience.)*

- [ ] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [ ] New feature has been introduced
    - If yes, how is this documented? (not applicable / docs / JavaDocs / not documented)
