### PR TITLE
[FLINK-35064] Update Pulsar dependency to solve the conflict of com.f…

### DIFF
--- a/flink-sql-connector-pulsar/pom.xml
+++ b/flink-sql-connector-pulsar/pom.xml
@@ -106,6 +106,10 @@ under the License.
 									<pattern>com.scurrilous</pattern>
 									<shadedPattern>org.apache.pulsar.shade.com.scurrilous</shadedPattern>
 								</relocation>
+								<relocation>
+									<pattern>com.fasterxml</pattern>
+									<shadedPattern>org.apache.pulsar.shade.com.fasterxml</shadedPattern>
+								</relocation>
 							</relocations>
 						</configuration>
 					</execution>


### PR DESCRIPTION
This PR fixes the conflict of com.fasterxml.jackson.annotation.JsonFormat$Value

## Purpose of the change

fixes the conflict of com.fasterxml.jackson.annotation.JsonFormat$Value 

## Brief change log

update pom.xml to relocate the 'com.fasterxml' classes to 'org.apache.pulsar.shade.com.fasterxml'

## Verifying this change

execute 'mvn clean package -DskipTests', then jar -tf flink-sql-connector-pulsar-4.2-SNAPSHOT.jar | grep 'com.fasterxml',  the original 'com.fasterxml' classes are now located under 'org.apache.pulsar.shade.com.fasterxml'

## Significant changes

*(Please check any boxes [x] if the answer is "yes". You can first publish the PR and check them afterwards, for
convenience.)*

- [ ] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [ ] New feature has been introduced
    - If yes, how is this documented? (not applicable / docs / JavaDocs / not documented)
