### PR TITLE
[FLINK-34961] Use dedicated CI name for Pulsar connector to differentiate it in infra-reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,10 @@
 # limitations under the License.
 ################################################################################
 
-name: CI
+# We need to specify repo related information here since Apache INFRA doesn't differentiate
+# between several workflows with the same names while preparing a report for GHA usage
+# https://infra-reports.apache.org/#ghactions
+name: Flink Connector Pulsar CI
 on:
   push:
     branches:

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -16,7 +16,10 @@
 # limitations under the License.
 ################################################################################
 
-name: Nightly
+# We need to specify repo related information here since Apache INFRA doesn't differentiate
+# between several workflows with the same names while preparing a report for GHA usage
+# https://infra-reports.apache.org/#ghactions
+name: Nightly Flink Connector Pulsar
 on:
   schedule:
     - cron: "0 0 * * *"


### PR DESCRIPTION
## Purpose of the change



The PR will allow to differentiate between Pulsar connector statistics and others with name ci


## Brief change log
GHA name change

## Verifying this change

This change is a trivial rework

