### PR TITLE
[FLINK-35182] Bump org.apache.commons:commons-compress from 1.24.0 to 1.26.1 for Flink Pulsar connector

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,9 @@ under the License.
         <slf4j.version>1.7.36</slf4j.version>
         <log4j.version>2.17.2</log4j.version>
         <jaxb-api.version>2.3.1</jaxb-api.version>
-        <commons-compress.version>1.24.0</commons-compress.version>
+        <commons-compress.version>1.26.1</commons-compress.version>
+        <commons-lang3.version>3.14.0</commons-lang3.version>
+        <commons-io.version>2.15.1</commons-io.version>
         <byte-buddy.version>1.12.20</byte-buddy.version>
         <kryo.version>2.24.0</kryo.version>
         <objenesis.version>3.3</objenesis.version>
@@ -395,6 +397,20 @@ under the License.
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-compress</artifactId>
                 <version>${commons-compress.version}</version>
+            </dependency>
+
+            <!-- For dependency convergence  -->
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>${commons-lang3.version}</version>
+            </dependency>
+
+            <!-- For dependency convergence  -->
+            <dependency>
+                <groupId>commons-io</groupId>
+                <artifactId>commons-io</artifactId>
+                <version>${commons-io.version}</version>
             </dependency>
 
             <!-- For dependency convergence -->


### PR DESCRIPTION
This closes https://github.com/apache/flink-connector-pulsar/pull/83.