### PR TITLE
[FLINK-35141][Connectors/Pulsar] Drop support for Flink 1.17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,15 +47,11 @@ jobs:
   compile_and_test:
     strategy:
       matrix:
-        flink: [ 1.17.1, 1.18.0 ]
-        jdk: [ 8, 11, 17 ]
-        exclude:
-          - jdk: 17
-            flink: 1.17.1
+        flink: [ 1.18.1, 1.19.0 ]
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:
       flink_version: ${{ matrix.flink }}
-      jdk_version: ${{ matrix.jdk }}
+      jdk_version: ${{ matrix.jdk || '8, 11, 17' }}
       timeout_global: 120
       timeout_test: 80
   check_dead_links:

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -31,29 +31,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jdk: [ 8, 11 ]
         flink_branches: [{
-          flink: 1.17-SNAPSHOT,
-          branch: main
-        }, {
           flink: 1.18-SNAPSHOT,
           branch: main
         }, {
-          flink: 1.16.2,
-          branch: v3.0
+          flink: 1.19-SNAPSHOT,
+          branch: main
         }, {
-          flink: 1.17.1,
-          branch: v4.0
+          flink: 1.20-SNAPSHOT,
+          branch: main
+        }, {
+          flink: 1.18.1,
+          branch: v4.1
+        }, {
+          flink: 1.19.0,
+          branch: v4.1
         }]
-        include:
-          - jdk: 17
-            flink_branches: {
-              flink: 1.18-SNAPSHOT,
-              branch: main
-            }
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:
-      jdk_version: ${{ matrix.jdk }}
+      jdk_version: ${{ matrix.jdk || '8, 11, 17' }}
       flink_version: ${{ matrix.flink_branches.flink }}
       connector_branch: ${{ matrix.flink_branches.branch }}
       run_dependency_convergence: false


### PR DESCRIPTION

## Purpose of the change

Drop support for Flink 1.17 and update CI for 1.18/1.19

