### PR TITLE
[FLINK-35468][Connectors/Pulsar] update isEnableAutoAcknowledgeMessage config comment

### DIFF
--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/config/SourceConfiguration.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/config/SourceConfiguration.java
@@ -108,15 +108,12 @@ public class SourceConfiguration extends PulsarConfiguration {
     }
 
     /**
-     * This is used for all subscription type. But the behavior may not be the same among them. If
-     * you don't enable the flink checkpoint, make sure this option is set to true.
+     * This is used for all subscription type.
+     * If you don't enable the flink checkpoint, please make sure this option is set to true.
+     * <p>
+     * {@link SubscriptionType#Failover} and {@link SubscriptionType#Exclusive} would perform
+     *  an incremental acknowledgment in a fixed {@link #getAutoCommitCursorInterval}.
      *
-     * <ul>
-     *   <li>{@link SubscriptionType#Shared} and {@link SubscriptionType#Key_Shared} would
-     *       immediately acknowledge the message after consuming it.
-     *   <li>{@link SubscriptionType#Failover} and {@link SubscriptionType#Exclusive} would perform
-     *       a incremental acknowledge in a fixed {@link #getAutoCommitCursorInterval}.
-     * </ul>
      */
     public boolean isEnableAutoAcknowledgeMessage() {
         return enableAutoAcknowledgeMessage;


### PR DESCRIPTION
<!--
*Thank you for contributing to Apache Flink Pulsar Connectors - we are happy that you want to help us improve our Flink connectors. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

- The name of the pull request should correspond to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
- Commits should be in the form of "[FLINK-XXXX][Component] Title of the pull request", where [FLINK-XXXX] should be replaced by the actual issue number.
    Generally, [Component] tag should indicate the part you modified. The options are: [Stream | Table | Test | E2E | Build].
    For example: "[FLINK-XXXX][Stream] XXXX" if you are working on the `DataStream` part of pulsar connector or "[FLINK-XXXX][Test] XXXX" if this pull request is only used for adding tests.
- Each pull request should only have one JIRA issue.
- Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

## Purpose of the change


Since we [deleted shared and key-shared subscription type](https://issues.apache.org/jira/browse/FLINK-30413) in pulsar source connector, I think it is better to remove these subscription type in isEnableAutoAcknowledgeMessage option comment to prevent misunderstanding.

## Brief change log
update SourceConfiguration.java `isEnableAutoAcknowledgeMessage` comment.

## Significant changes

- [ ] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [ ] New feature has been introduced
