### PR TITLE
[hotfix] Refactor callers that use deprecated get/setXXX of Configuration

### DIFF
--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/config/SinkConfiguration.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/config/SinkConfiguration.java
@@ -61,9 +61,9 @@ public class SinkConfiguration extends PulsarConfiguration {
         super(configuration);
 
         this.deliveryGuarantee = get(PULSAR_WRITE_DELIVERY_GUARANTEE);
-        this.transactionTimeoutMillis = getLong(PULSAR_WRITE_TRANSACTION_TIMEOUT);
-        this.topicMetadataRefreshInterval = getLong(PULSAR_TOPIC_METADATA_REFRESH_INTERVAL);
-        this.partitionSwitchSize = getInteger(PULSAR_BATCHING_MAX_MESSAGES);
+        this.transactionTimeoutMillis = get(PULSAR_WRITE_TRANSACTION_TIMEOUT);
+        this.topicMetadataRefreshInterval = get(PULSAR_TOPIC_METADATA_REFRESH_INTERVAL);
+        this.partitionSwitchSize = get(PULSAR_BATCHING_MAX_MESSAGES);
         this.messageKeyHash = get(PULSAR_MESSAGE_KEY_HASH);
         this.enableSchemaEvolution = get(PULSAR_WRITE_SCHEMA_EVOLUTION);
         this.maxRecommitTimes = get(PULSAR_MAX_RECOMMIT_TIMES);

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/config/SourceConfiguration.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/config/SourceConfiguration.java
@@ -72,7 +72,7 @@ public class SourceConfiguration extends PulsarConfiguration {
     public SourceConfiguration(Configuration configuration) {
         super(configuration);
 
-        this.messageQueueCapacity = getInteger(ELEMENT_QUEUE_CAPACITY);
+        this.messageQueueCapacity = get(ELEMENT_QUEUE_CAPACITY);
         this.partitionDiscoveryIntervalMs = get(PULSAR_PARTITION_DISCOVERY_INTERVAL_MS);
         this.enableAutoAcknowledgeMessage = get(PULSAR_ENABLE_AUTO_ACKNOWLEDGE_MESSAGE);
         this.autoCommitCursorInterval = get(PULSAR_AUTO_COMMIT_CURSOR_INTERVAL);


### PR DESCRIPTION
## Purpose of the change

getLong and getInteger are removing in Flink 2.0, we should refactor them to get method.

Note: It blocks https://github.com/apache/flink/pull/25000.

Because flink-python module depends on the `flink-sql-connector-pulsar` , version : `4.0.0-1.17`.

But when `getLong and getInteger` are removed, `flink-sql-connector-pulsar` and `4.0.0-1.17` is still using them. So the CI will be failed.

https://dev.azure.com/apache-flink/apache-flink/_build/results?buildId=62127&view=logs&j=9cada3cb-c1d3-5621-16da-0f718fb86602&t=c67e71ed-6451-5d26-8920-5a8cf9651901&l=25266
