### PR TITLE
[FLINK-36595][docs] Explicitly set connector compatibility as string …

### DIFF
--- a/docs/data/pulsar.yml
+++ b/docs/data/pulsar.yml
@@ -17,7 +17,7 @@
 ################################################################################
 
 version: 4.1.0
-flink_compatibility: [1.17, 1.18]
+flink_compatibility: ["1.17", "1.18"]
 variants:
   - maven: flink-connector-pulsar
     sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-pulsar/$full_version/flink-sql-connector-pulsar-$full_version.jar


### PR DESCRIPTION
…to prevent version comparison mismatch

## Purpose of the change

* Set version as string to prevent version comparison mismatch. Issue has happened for other connectors too : https://github.com/apache/flink-connector-kafka/pull/132

## Brief change log

* Set version as string to prevent version comparison mismatch. Issue has happened for other connectors too : https://github.com/apache/flink-connector-kafka/pull/132

## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.

## Significant changes

*(Please check any boxes [x] if the answer is "yes". You can first publish the PR and check them afterwards, for
convenience.)*

- [ ] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [ ] New feature has been introduced
    - If yes, how is this documented? (not applicable / docs / JavaDocs / not documented)
