### PR TITLE
[FLINK-37299][Connector/Pulsar] Flink stateless startup cannot contin…

### DIFF
--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/PulsarSourceEnumerator.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/PulsarSourceEnumerator.java
@@ -220,7 +220,10 @@ public class PulsarSourceEnumerator
                     startCursor.position(partition.getTopic(), partition.getPartitionId());
 
             try {
-                position.setupSubPosition(pulsarClient, topic, subscriptionName);
+                //If resetSubscriptionCursor is set to true, the position is reset to the position specified by StartCursor each time
+                if (sourceConfiguration.isResetSubscriptionCursor()) {
+                    position.setupSubPosition(pulsarClient, topic, subscriptionName);
+                }
             } catch (PulsarClientException e) {
                 throw new FlinkRuntimeException(e);
             }


### PR DESCRIPTION
## Purpose of the change

Controls whether Flink continues to consume from the location recorded by the consumer group or from the location specified by StartCursor when it starts from stateless.

1、If 'pulsar.source.resetSubscriptionCursor' = 'true', each time a Flink task is restarted, it will consume according to the consumption location specified by the StartCursor configuration. 
2、If 'pulsar.source.resetSubscriptionCursor' = 'fasle', no matter what value 'StartCursor' is set to, each restart will start consuming from the location recorded by the consumer group.

## Brief change log
The value of pulsar.source.resetSubscriptionCursor determines whether Flink continues to consume from the location recorded by the consumer group or from the location specified by StartCursor when it starts from stateless.

## Verifying this change
This change is a minor change and don't have any tests.

## Significant changes

*(Please check any boxes [x] if the answer is "yes". You can first publish the PR and check them afterwards, for
convenience.)*

- [ ] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [ ] New feature has been introduced
    - If yes, how is this documented? (not applicable / docs / JavaDocs / not documented)
