### PR TITLE
[FLINK-37436] Fix that flink-connector-pulsar used a incorrect API when dynamically creating topics by DynamicTopicRouter

### DIFF
--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/topic/ProducerRegister.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/topic/ProducerRegister.java
@@ -47,6 +47,7 @@ import org.apache.pulsar.client.impl.TypedMessageBuilderImpl;
 import org.apache.pulsar.client.impl.conf.ProducerConfigurationData;
 import org.apache.pulsar.client.impl.transaction.TransactionImpl;
 import org.apache.pulsar.common.api.proto.MessageMetadata;
+import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.protocol.schema.SchemaHash;
 import org.apache.pulsar.common.schema.SchemaType;
 import org.apache.pulsar.shade.com.google.common.base.Strings;
@@ -218,6 +219,12 @@ public class ProducerRegister implements Closeable {
         try {
             // Use this method for auto creating the non-exist topics. Otherwise, it will throw an
             // exception.
+            TopicName topicName = TopicName.get(topic);
+            // Step-1: create partitioned topic metadata.
+            if (topicName.isPartitioned()) {
+                pulsarClient.getPartitionsForTopic(TopicName.get(topic).getPartitionedTopicName()).get();
+            }
+            // Step-2: create partition.
             pulsarClient.getPartitionsForTopic(topic).get();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();


### PR DESCRIPTION
## Purpose of the change
#### Background 1: dynamically create a Pulsar Topic by Flink connector-pulsar

Flink connector-pulsar provided a way to dynamically create a Pulsar Topic when DynamicTopicRouter returns a non-existing one. see also: [flink-connector-pulsar/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/topic/ProducerRegister.java at main · apache/flink-connector-pulsar](https://github.com/apache/flink-connector-pulsar/blob/main/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/topic/ProducerRegister.java#L221). 
- `pulsarClient.getPartitionsForTopic(topic)` will create a topic automatically if it does not exist.

#### Background 2:  how dynamically created topics in Pulsar Server

- There is a config named `allowAutoTopicCreationType`, which can be set to `
partitioned` or `non-partitioned`
- If it was set `partitioned`, Pulsar will create a partitioned topic with ` {defaultNumPartitions}` partitions. For example, Pulsar will create topics named `{tenant}/{namespace}/{topic name}-partition-0` and `{tenant}/{namespace}/{topic name}-partition-1`, and create a relationship between them, which indicates they are in a same partitioned topic.
- If it was set `non-partitioned`, Pulsar will create a non-partitioned topic. Pulsar will create topics named `{tenant}/{namespace}/{topic name}`, which does not include a suffix `partition-{num}`.
 
#### Issue:

- if `pulsarClient.getPartitionsForTopic(topic)` get a param `{tenant}/{namespace}/{topic name}-partition-0`, which includes the suffix `partition-0`, Pulsar will create a non-partitioned topic named `{tenant}/{namespace}/{topic name}-partition-0`
- After you call `pulsarClient.getPartitionsForTopic(topic)` with a param `{tenant}/{namespace}/{topic name}-partition-1`, you will get two partitions named `{tenant}/{namespace}/{topic name}-partition-0` and `{tenant}/{namespace}/{topic name}-partition-1`, but there is no relationship record between them.

## Brief change log

Fix the incorrect API calling.

## Verifying this change

This change is a minor change and don't have any tests.

## Significant changes

*(Please check any boxes [x] if the answer is "yes". You can first publish the PR and check them afterwards, for
convenience.)*

- [ ] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [ ] New feature has been introduced
    - If yes, how is this documented? (not applicable / docs / JavaDocs / not documented)
