### PR TITLE
[FLINK-36235][Stream] Ignore emitting null rowData when deserialized message fails

### DIFF
--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/deserializer/GenericRecordDeserializationSchema.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/deserializer/GenericRecordDeserializationSchema.java
@@ -11,6 +11,8 @@ import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.client.impl.schema.AutoConsumeSchema;
 import org.apache.pulsar.client.impl.schema.generic.MultiVersionSchemaInfoProvider;
 import org.apache.pulsar.common.naming.TopicName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -22,6 +24,9 @@ import java.util.Map;
 @Internal
 public class GenericRecordDeserializationSchema<T> implements PulsarDeserializationSchema<T> {
     private static final long serialVersionUID = 1133225716807307498L;
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(GenericRecordDeserializationSchema.class);
 
     private transient PulsarClientImpl client;
     private transient Map<String, AutoConsumeSchema> schemaMap;
@@ -38,7 +43,11 @@ public class GenericRecordDeserializationSchema<T> implements PulsarDeserializat
         GenericRecord element = schema.decode(message.getData(), message.getSchemaVersion());
         T msg = deserializer.deserialize(element);
 
-        out.collect(msg);
+        if (msg != null) {
+            out.collect(msg);
+        } else {
+            LOG.debug("Dropped null record for Pulsar message ID: {}", message.getMessageId());
+        }
     }
 
     @Override

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/deserializer/PulsarDeserializationSchemaWrapper.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/deserializer/PulsarDeserializationSchemaWrapper.java
@@ -25,6 +25,8 @@ import org.apache.flink.connector.pulsar.source.config.SourceConfiguration;
 import org.apache.flink.util.Collector;
 
 import org.apache.pulsar.client.api.Message;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A {@link PulsarDeserializationSchema} implementation which based on the given flink's {@link
@@ -36,6 +38,9 @@ import org.apache.pulsar.client.api.Message;
 @Internal
 public class PulsarDeserializationSchemaWrapper<T> implements PulsarDeserializationSchema<T> {
     private static final long serialVersionUID = -630646912412751300L;
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(PulsarDeserializationSchemaWrapper.class);
 
     private final DeserializationSchema<T> deserializationSchema;
 
@@ -58,6 +63,8 @@ public class PulsarDeserializationSchemaWrapper<T> implements PulsarDeserializat
         // Per DeserializationSchema contract, null means "drop this record".
         if (instance != null) {
             out.collect(instance);
+        } else {
+            LOG.debug("Dropped null record for Pulsar message ID: {}", message.getMessageId());
         }
     }
 

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/deserializer/PulsarDeserializationSchemaWrapper.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/deserializer/PulsarDeserializationSchemaWrapper.java
@@ -55,7 +55,10 @@ public class PulsarDeserializationSchemaWrapper<T> implements PulsarDeserializat
         byte[] bytes = message.getData();
         T instance = deserializationSchema.deserialize(bytes);
 
-        out.collect(instance);
+        // Per DeserializationSchema contract, null means "drop this record".
+        if (instance != null) {
+            out.collect(instance);
+        }
     }
 
     @Override

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/deserializer/PulsarSchemaWrapper.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/deserializer/PulsarSchemaWrapper.java
@@ -26,6 +26,8 @@ import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.common.schema.SchemaInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.apache.flink.connector.pulsar.common.schema.PulsarSchemaUtils.createTypeInformation;
 
@@ -38,6 +40,8 @@ import static org.apache.flink.connector.pulsar.common.schema.PulsarSchemaUtils.
 @Internal
 public class PulsarSchemaWrapper<T> implements PulsarDeserializationSchema<T> {
     private static final long serialVersionUID = -4864701207257059158L;
+
+    private static final Logger LOG = LoggerFactory.getLogger(PulsarSchemaWrapper.class);
 
     /** The serializable pulsar schema, it wrap the schema with type class. */
     private final PulsarSchema<T> pulsarSchema;
@@ -65,7 +69,11 @@ public class PulsarSchemaWrapper<T> implements PulsarDeserializationSchema<T> {
         byte[] bytes = message.getData();
         T instance = schema.decode(bytes);
 
-        out.collect(instance);
+        if (instance != null) {
+            out.collect(instance);
+        } else {
+            LOG.debug("Dropped null record for Pulsar message ID: {}", message.getMessageId());
+        }
     }
 
     @Override

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/deserializer/PulsarTypeInformationWrapper.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/deserializer/PulsarTypeInformationWrapper.java
@@ -26,6 +26,8 @@ import org.apache.flink.core.memory.DataInputDeserializer;
 import org.apache.flink.util.Collector;
 
 import org.apache.pulsar.client.api.Message;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Wrap the flink TypeInformation into a {@code PulsarDeserializationSchema}. We would create a
@@ -35,6 +37,8 @@ import org.apache.pulsar.client.api.Message;
 @Internal
 public class PulsarTypeInformationWrapper<T> implements PulsarDeserializationSchema<T> {
     private static final long serialVersionUID = 6647084180084963022L;
+
+    private static final Logger LOG = LoggerFactory.getLogger(PulsarTypeInformationWrapper.class);
 
     /**
      * PulsarDeserializationSchema would be shared for multiple SplitReaders in different fetcher
@@ -58,7 +62,11 @@ public class PulsarTypeInformationWrapper<T> implements PulsarDeserializationSch
         dis.setBuffer(message.getData());
         T instance = serializer.deserialize(dis);
 
-        out.collect(instance);
+        if (instance != null) {
+            out.collect(instance);
+        } else {
+            LOG.debug("Dropped null record for Pulsar message ID: {}", message.getMessageId());
+        }
     }
 
     @Override

--- a/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/reader/deserializer/GenericRecordDeserializationSchemaTest.java
+++ b/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/reader/deserializer/GenericRecordDeserializationSchemaTest.java
@@ -107,6 +107,36 @@ class GenericRecordDeserializationSchemaTest extends PulsarTestSuiteBase {
         }
     }
 
+    @Test
+    void deserializeDropsNullRecords() throws Exception {
+        String topic = "generic-record-null-" + randomAlphanumeric(10);
+        operator().createTopic(topic, 1);
+
+        Bar bar = new Bar(random.nextBoolean(), randomAlphanumeric(10));
+        operator().sendMessage(topic, Schema.AVRO(Bar.class), bar);
+
+        PulsarSource<String> source =
+                PulsarSource.builder()
+                        .setDeserializationSchema(
+                                new GenericRecordDeserializationSchema<>(
+                                        new NullReturningGenericRecordDeserializer()))
+                        .setServiceUrl(operator().serviceUrl())
+                        .setTopics(topic)
+                        .setStartCursor(StartCursor.earliest())
+                        .setBoundedStopCursor(StopCursor.latest())
+                        .setSubscriptionName("generic-record-null")
+                        .build();
+
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(1);
+
+        DataStreamSource<String> stream =
+                env.fromSource(source, noWatermarks(), "null-record-deserializer");
+        List<String> results = stream.executeAndCollect(1);
+
+        assertThat(results).isEmpty();
+    }
+
     @Override
     protected PulsarRuntime runtime() {
         return PulsarRuntime.container();
@@ -130,6 +160,22 @@ class GenericRecordDeserializationSchemaTest extends PulsarTestSuiteBase {
                             org.apache.pulsar.shade.org.apache.avro.generic.GenericRecord.class);
 
             return object.toString();
+        }
+
+        @Override
+        public TypeInformation<String> getProducedType() {
+            return Types.STRING;
+        }
+    }
+
+    private static class NullReturningGenericRecordDeserializer
+            implements GenericRecordDeserializer<String> {
+        private static final long serialVersionUID = 5260115535492423071L;
+
+        @Override
+        public String deserialize(GenericRecord message) {
+            assertThat(message.getSchemaType()).isEqualTo(SchemaType.AVRO);
+            return null;
         }
 
         @Override

--- a/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/reader/deserializer/PulsarDeserializationSchemaTest.java
+++ b/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/reader/deserializer/PulsarDeserializationSchemaTest.java
@@ -20,12 +20,16 @@ package org.apache.flink.connector.pulsar.source.reader.deserializer;
 
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.functions.util.ListCollector;
 import org.apache.flink.api.common.serialization.AbstractDeserializationSchema;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.serialization.SimpleStringSchema;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.pulsar.SampleMessage.TestMessage;
+import org.apache.flink.connector.pulsar.common.schema.PulsarSchema;
 import org.apache.flink.connector.pulsar.source.PulsarSource;
 import org.apache.flink.connector.pulsar.source.PulsarSourceOptions;
 import org.apache.flink.connector.pulsar.source.config.SourceConfiguration;
@@ -34,6 +38,7 @@ import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicNameUtils;
 import org.apache.flink.connector.pulsar.source.reader.deserializer.PulsarDeserializationSchema.PulsarInitializationContext;
 import org.apache.flink.connector.pulsar.testutils.PulsarTestSuiteBase;
 import org.apache.flink.connector.testutils.source.deserialization.TestingDeserializationContext;
+import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputSerializer;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.types.StringValue;
@@ -51,6 +56,7 @@ import org.apache.pulsar.common.schema.KeyValue;
 import org.junit.jupiter.api.Test;
 
 import java.io.Serializable;
+import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
@@ -63,6 +69,9 @@ import static org.apache.flink.util.Preconditions.checkState;
 import static org.apache.pulsar.client.api.Schema.PROTOBUF_NATIVE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /** Unit tests for {@link PulsarDeserializationSchema}. */
 class PulsarDeserializationSchemaTest extends PulsarTestSuiteBase {
@@ -100,10 +109,45 @@ class PulsarDeserializationSchemaTest extends PulsarTestSuiteBase {
         schema.open(new PulsarTestingDeserializationContext(), sourceConfig);
 
         Message<byte[]> message = getMessage("ignored", String::getBytes);
-        CountingCollector<String> collector = new CountingCollector<>();
+        List<String> records = new ArrayList<>();
+        ListCollector<String> collector = new ListCollector<>(records);
         schema.deserialize(message, collector);
 
-        assertThat(collector.collected).isEmpty();
+        assertThat(records).isEmpty();
+    }
+
+    @Test
+    void pulsarSchemaWrapperDropsNullDecodedRecord() throws Exception {
+        @SuppressWarnings("unchecked")
+        Schema<String> pulsarSchema = mock(Schema.class);
+        when(pulsarSchema.decode(any(byte[].class))).thenReturn(null);
+        PulsarSchema<String> serializableSchema = new PulsarSchema<>(Schema.STRING);
+        setPulsarSchema(serializableSchema, pulsarSchema);
+        PulsarDeserializationSchema<String> schema = new PulsarSchemaWrapper<>(serializableSchema);
+
+        Message<byte[]> message = getMessage("ignored", String::getBytes);
+        List<String> records = new ArrayList<>();
+        schema.deserialize(message, new ListCollector<>(records));
+
+        assertThat(records).isEmpty();
+    }
+
+    @Test
+    void typeInformationWrapperDropsNullDeserializedRecord() throws Exception {
+        @SuppressWarnings("unchecked")
+        TypeInformation<String> typeInformation = mock(TypeInformation.class);
+        @SuppressWarnings("unchecked")
+        TypeSerializer<String> serializer = mock(TypeSerializer.class);
+        when(typeInformation.createSerializer(any(ExecutionConfig.class))).thenReturn(serializer);
+        when(serializer.deserialize(any(DataInputView.class))).thenReturn(null);
+        PulsarDeserializationSchema<String> schema =
+                new PulsarTypeInformationWrapper<>(typeInformation, new ExecutionConfig());
+
+        Message<byte[]> message = getMessage("ignored", String::getBytes);
+        List<String> records = new ArrayList<>();
+        schema.deserialize(message, new ListCollector<>(records));
+
+        assertThat(records).isEmpty();
     }
 
     @Test
@@ -399,20 +443,11 @@ class PulsarDeserializationSchemaTest extends PulsarTestSuiteBase {
         return MessageImpl.create(metadata, payload, Schema.BYTES, "");
     }
 
-    /** Collector that records every {@link #collect} invocation, including nulls. */
-    private static class CountingCollector<T> implements Collector<T> {
-
-        private final List<T> collected = new ArrayList<>();
-
-        @Override
-        public void collect(T record) {
-            collected.add(record);
-        }
-
-        @Override
-        public void close() {
-            // do nothing
-        }
+    private static <T> void setPulsarSchema(PulsarSchema<T> serializableSchema, Schema<T> schema)
+            throws Exception {
+        Field schemaField = PulsarSchema.class.getDeclaredField("schema");
+        schemaField.setAccessible(true);
+        schemaField.set(serializableSchema, schema);
     }
 
     /** This collector is used for collecting only one message. Used for test purpose. */

--- a/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/reader/deserializer/PulsarDeserializationSchemaTest.java
+++ b/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/reader/deserializer/PulsarDeserializationSchemaTest.java
@@ -20,6 +20,8 @@ package org.apache.flink.connector.pulsar.source.reader.deserializer;
 
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.serialization.AbstractDeserializationSchema;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.serialization.SimpleStringSchema;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.configuration.Configuration;
@@ -50,6 +52,8 @@ import org.junit.jupiter.api.Test;
 
 import java.io.Serializable;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -78,6 +82,28 @@ class PulsarDeserializationSchemaTest extends PulsarTestSuiteBase {
         schema.deserialize(message, collector);
 
         assertThat(collector.result).isNotNull().isEqualTo(content);
+    }
+
+    @Test
+    void wrapperDropsNullDeserializedRecord() throws Exception {
+        DeserializationSchema<String> nullReturningSchema =
+                new AbstractDeserializationSchema<String>() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public String deserialize(byte[] message) {
+                        return null;
+                    }
+                };
+        PulsarDeserializationSchema<String> schema =
+                new PulsarDeserializationSchemaWrapper<>(nullReturningSchema);
+        schema.open(new PulsarTestingDeserializationContext(), sourceConfig);
+
+        Message<byte[]> message = getMessage("ignored", String::getBytes);
+        CountingCollector<String> collector = new CountingCollector<>();
+        schema.deserialize(message, collector);
+
+        assertThat(collector.collected).isEmpty();
     }
 
     @Test
@@ -371,6 +397,22 @@ class PulsarDeserializationSchemaTest extends PulsarTestSuiteBase {
         ByteBuffer payload = ByteBuffer.wrap(bytes);
 
         return MessageImpl.create(metadata, payload, Schema.BYTES, "");
+    }
+
+    /** Collector that records every {@link #collect} invocation, including nulls. */
+    private static class CountingCollector<T> implements Collector<T> {
+
+        private final List<T> collected = new ArrayList<>();
+
+        @Override
+        public void collect(T record) {
+            collected.add(record);
+        }
+
+        @Override
+        public void close() {
+            // do nothing
+        }
     }
 
     /** This collector is used for collecting only one message. Used for test purpose. */


### PR DESCRIPTION
## Purpose of the change

This PR fixes [FLINK-36235](https://issues.apache.org/jira/browse/FLINK-36235). 
Currently, when a message fails to deserialize and returns `null`, the `PulsarDeserializationSchemaWrapper` emits this `null` value downstream. This violates Flink's `DeserializationSchema` contract (where a `null` return value means "drop this record") and can cause `NullPointerException`s in downstream operators. This PR adds a simple null-check guard to safely drop these corrupted or null records.

## Brief change log

- Added an `if (instance != null)` check before emitting the record in `PulsarDeserializationSchemaWrapper#deserialize`.
- Added a regression test `wrapperDropsNullDeserializedRecord` and a `CountingCollector` helper class in `PulsarDeserializationSchemaTest` to verify that null records are correctly dropped without errors.

## Verifying this change

This change added tests and can be verified as follows:

- Added unit tests in `PulsarDeserializationSchemaTest.java` to explicitly test and verify the filtering behavior when the inner deserializer returns `null`.
- Verified locally using `mvn -pl flink-connector-pulsar test`.

## Significant changes

- [ ] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [ ] New feature has been introduced
    - If yes, how is this documented? (not applicable / docs / JavaDocs / not documented)