### PR TITLE
[FLINK-40206][Stream] Upgrade pulsar-client to 3.0.17 to address critical vulnerabilities

### DIFF
--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/topic/MetadataListener.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/topic/MetadataListener.java
@@ -27,10 +27,9 @@ import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicMetadata;
 import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicPartition;
 import org.apache.flink.util.FlinkRuntimeException;
 
+import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
-import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.common.naming.TopicName;
-import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
 import org.apache.pulsar.shade.com.google.common.cache.CacheBuilder;
 import org.apache.pulsar.shade.com.google.common.cache.CacheLoader;
 import org.apache.pulsar.shade.com.google.common.cache.LoadingCache;
@@ -69,7 +68,7 @@ public class MetadataListener implements Serializable, Closeable {
     private ImmutableList<TopicPartition> availablePartitions;
 
     // Dynamic fields.
-    private transient PulsarClientImpl clientImpl;
+    private transient PulsarClient client;
     private transient Long topicMetadataRefreshInterval;
     private transient ProcessingTimeService timeService;
     private transient LoadingCache<String, Optional<Integer>> topicPartitionCache;
@@ -99,7 +98,7 @@ public class MetadataListener implements Serializable, Closeable {
     public void open(SinkConfiguration sinkConfiguration, ProcessingTimeService timeService)
             throws PulsarClientException {
         // Initialize listener properties.
-        this.clientImpl = (PulsarClientImpl) createClient(sinkConfiguration);
+        this.client = createClient(sinkConfiguration);
         this.topicMetadataRefreshInterval = sinkConfiguration.getTopicMetadataRefreshInterval();
         this.timeService = timeService;
         this.topicPartitionCache =
@@ -111,9 +110,12 @@ public class MetadataListener implements Serializable, Closeable {
                                     @ParametersAreNonnullByDefault
                                     public Optional<Integer> load(String topic)
                                             throws ExecutionException, InterruptedException {
-                                        PartitionedTopicMetadata metadata =
-                                                clientImpl.getPartitionedTopicMetadata(topic).get();
-                                        return Optional.of(metadata.partitions);
+                                        List<String> partitions =
+                                                client.getPartitionsForTopic(topic).get();
+                                        if (!TopicName.get(partitions.get(0)).isPartitioned()) {
+                                            return Optional.of(NON_PARTITIONED);
+                                        }
+                                        return Optional.of(partitions.size());
                                     }
                                 });
 
@@ -162,8 +164,8 @@ public class MetadataListener implements Serializable, Closeable {
 
     @Override
     public void close() throws IOException {
-        if (clientImpl != null) {
-            clientImpl.close();
+        if (client != null) {
+            client.close();
         }
     }
 

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/subscriber/impl/BasePulsarSubscriber.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/subscriber/impl/BasePulsarSubscriber.java
@@ -25,8 +25,7 @@ import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicRange;
 import org.apache.flink.connector.pulsar.source.enumerator.topic.range.RangeGenerator;
 
 import org.apache.pulsar.client.api.PulsarClient;
-import org.apache.pulsar.client.impl.PulsarClientImpl;
-import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
+import org.apache.pulsar.common.naming.TopicName;
 
 import java.util.HashSet;
 import java.util.List;
@@ -52,12 +51,12 @@ public abstract class BasePulsarSubscriber implements PulsarSubscriber {
             return new TopicMetadata(topic, NON_PARTITIONED);
         }
 
-        PulsarClientImpl clientImpl = (PulsarClientImpl) client;
-        PartitionedTopicMetadata metadata = clientImpl.getPartitionedTopicMetadata(topic).get();
-        if (metadata.partitions == NON_PARTITIONED) {
+        List<String> partitions = client.getPartitionsForTopic(topic).get();
+        if (!TopicName.get(partitions.get(0)).isPartitioned()) {
             NON_PARTITIONED_TOPICS.add(topic);
+            return new TopicMetadata(topic, NON_PARTITIONED);
         }
-        return new TopicMetadata(topic, metadata.partitions);
+        return new TopicMetadata(topic, partitions.size());
     }
 
     protected Set<TopicPartition> createTopicPartitions(

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@ under the License.
 
     <properties>
         <flink.version>1.20.3</flink.version>
-        <pulsar.version>3.0.5</pulsar.version>
+        <pulsar.version>3.0.17</pulsar.version>
         <scala.binary.version>2.12</scala.binary.version>
         <bouncycastle.version>1.69</bouncycastle.version>
 
@@ -79,7 +79,7 @@ under the License.
         <byte-buddy.version>1.12.20</byte-buddy.version>
         <kryo.version>2.24.0</kryo.version>
         <objenesis.version>3.3</objenesis.version>
-        <jackson-bom.version>2.13.4.20221013</jackson-bom.version>
+        <jackson-bom.version>2.17.3</jackson-bom.version>
         <snappy.java.version>1.1.10.4</snappy.java.version>
 
         <os-maven-plugin.version>1.7.0</os-maven-plugin.version>


### PR DESCRIPTION
## Purpose of the change

Upgrade the bundled `pulsar-client-all` from 3.0.5 to the latest 3.0.x patch, 3.0.17, to clear two critical CVEs carried by its shaded dependencies: avro (CVE-2023-39410, GHSA-r7pg-v2c8-mfg3) and async-http-client (CVE-2024-53990, GHSA-mfj5-cf8g-g2fv).

A straight version bump breaks at runtime: the connector queries topic metadata through the internal `PulsarClientImpl.getPartitionedTopicMetadata(String)`, which was removed in pulsar-client 3.0.8, causing `NoSuchMethodError` in both the source enumerator and the sink metadata listener. This change first moves those call sites to the public `PulsarClient` API so the connector no longer depends on the implementation class, then performs the upgrade.

## Brief change log

- Query topic metadata via the public `PulsarClient.getPartitionsForTopic(String)` instead of the internal `PulsarClientImpl.getPartitionedTopicMetadata(String)`, in `BasePulsarSubscriber` (source enumerator) and `MetadataListener` (sink). `getPartitionsForTopic` returns the topic name itself for a non-partitioned topic and the partition names otherwise, so non-partitioned topics are detected via `TopicName#isPartitioned` on the first returned entry, preserving the previous `NON_PARTITIONED` semantics and caching behaviour.
- Bump `pulsar.version` 3.0.5 -> 3.0.17.
- Bump `jackson-bom.version` 2.13.4 -> 2.17.3 to match the jackson-databind shaded into `pulsar-client-all` 3.0.17: its shaded `EnumDeserializer` references `JsonFormat.Feature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE`, which only exists in jackson-annotations 2.15+, so client creation otherwise fails with `NoSuchFieldError`.

## Verifying this change

This change is already covered by existing tests that resolve topic metadata for both partitioned and non-partitioned topics against a real Pulsar broker, such as `PulsarSubscriberTest`, `PulsarSourceITCase`, `PulsarSinkITCase`, and the metadata-listener / split-reader reader tests. No behavioural change is expected — only the underlying client call and the dependency versions change.

## Significant changes

- [x] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [ ] New feature has been introduced
    - If yes, how is this documented? (not applicable / docs / JavaDocs / not documented)
